### PR TITLE
Add "ValueGenerated" mapping config for computed columns

### DIFF
--- a/src/EntityFrameworkCore.Generator.Core/ModelGenerator.cs
+++ b/src/EntityFrameworkCore.Generator.Core/ModelGenerator.cs
@@ -165,6 +165,9 @@ namespace EntityFrameworkCore.Generator
                 property.Default = column.DefaultValueSql;
                 property.ValueGenerated = column.ValueGenerated;
 
+                if (property.ValueGenerated == null && !string.IsNullOrWhiteSpace(column.ComputedColumnSql))
+                    property.ValueGenerated = ValueGenerated.OnAddOrUpdate;
+
                 var mapping = _typeMapper.ParseType(column.StoreType);
                 property.StoreType = mapping.StoreType;
                 property.NativeType = mapping.NativeType;


### PR DESCRIPTION
For computed column "column.ValueGenerated" is null but the "ValueGenerated" property must be "ValueGenerated.OnAddOrUpdate".

if "ComputedColumnSql" is not null or empty the "ValueGenerated" set to "ValueGenerated.OnAddOrUpdate".