### PR TITLE
Add schema to namespace

### DIFF
--- a/src/EntityFrameworkCore.Generator.Core/CodeGenerator.cs
+++ b/src/EntityFrameworkCore.Generator.Core/CodeGenerator.cs
@@ -76,6 +76,8 @@ namespace EntityFrameworkCore.Generator
                 var directory = Options.Data.Query.Directory;
                 var file = entity.EntityClass + "Extensions.cs";
                 var path = Path.Combine(directory, file);
+                if (Options.Project.AddSchemaToNamespace && !string.IsNullOrEmpty(entity.TableSchema))
+                    path = Path.Combine(directory, entity.TableSchema, file);
 
                 _logger.LogInformation(File.Exists(path)
                     ? "Updating query extensions class: {file}"
@@ -97,6 +99,8 @@ namespace EntityFrameworkCore.Generator
                 var directory = Options.Data.Mapping.Directory;
                 var file = entity.MappingClass + ".cs";
                 var path = Path.Combine(directory, file);
+                if (Options.Project.AddSchemaToNamespace && !string.IsNullOrEmpty(entity.TableSchema))
+                    path = Path.Combine(directory, entity.TableSchema, file);
 
                 _logger.LogInformation(File.Exists(path)
                     ? "Updating mapping class: {file}"
@@ -118,6 +122,8 @@ namespace EntityFrameworkCore.Generator
                 var directory = Options.Data.Entity.Directory;
                 var file = entity.EntityClass + ".cs";
                 var path = Path.Combine(directory, file);
+                if (Options.Project.AddSchemaToNamespace && !string.IsNullOrEmpty(entity.TableSchema))
+                    path = Path.Combine(directory, entity.TableSchema, file);
 
                 _logger.LogInformation(File.Exists(path)
                     ? "Updating entity class: {file}"
@@ -172,6 +178,8 @@ namespace EntityFrameworkCore.Generator
                 var directory = GetModelDirectory(model);
                 var file = model.ModelClass + ".cs";
                 var path = Path.Combine(directory, file);
+                if (Options.Project.AddSchemaToNamespace && !string.IsNullOrEmpty(entity.TableSchema))
+                    path = Path.Combine(directory, entity.TableSchema, file);
 
                 _logger.LogInformation(File.Exists(path)
                     ? "Updating model class: {file}"
@@ -219,6 +227,8 @@ namespace EntityFrameworkCore.Generator
                 var directory = Options.Model.Validator.Directory;
                 var file = model.ValidatorClass + ".cs";
                 var path = Path.Combine(directory, file);
+                if (Options.Project.AddSchemaToNamespace && !string.IsNullOrEmpty(entity.TableSchema))
+                    path = Path.Combine(directory, entity.TableSchema, file);
 
                 _logger.LogInformation(File.Exists(path)
                     ? "Updating validation class: {file}"
@@ -240,6 +250,8 @@ namespace EntityFrameworkCore.Generator
             var directory = Options.Model.Mapper.Directory;
             var file = entity.MapperClass + ".cs";
             var path = Path.Combine(directory, file);
+            if (Options.Project.AddSchemaToNamespace && !string.IsNullOrEmpty(entity.TableSchema))
+                path = Path.Combine(directory, entity.TableSchema, file);
 
             _logger.LogInformation(File.Exists(path)
                 ? "Updating object mapper class: {file}"

--- a/src/EntityFrameworkCore.Generator.Core/Metadata/Generation/Entity.cs
+++ b/src/EntityFrameworkCore.Generator.Core/Metadata/Generation/Entity.cs
@@ -55,6 +55,15 @@ namespace EntityFrameworkCore.Generator.Metadata.Generation
         public string EntityClass { get; set; }
 
         /// <summary>
+        /// Gets the fully qualified name of the type, including its namespace but not its assembly.
+        /// https://docs.microsoft.com/en-us/dotnet/api/system.type.fullname
+        /// </summary>
+        public string EntityFullName
+        {
+            get { return $"{EntityNamespace}.{EntityClass}"; }
+        }
+
+        /// <summary>
         /// Gets or sets the entity base class.
         /// </summary>
         /// <value>

--- a/src/EntityFrameworkCore.Generator.Core/ModelGenerator.cs
+++ b/src/EntityFrameworkCore.Generator.Core/ModelGenerator.cs
@@ -120,7 +120,7 @@ namespace EntityFrameworkCore.Generator
             mappingName = _namer.UniqueModelName(mappingNamespace ,mappingName);
 
 
-            string contextName = ContextName(entityClass);
+            string contextName = ContextName(entityClass, tableSchema.Schema);
             contextName = ToPropertyName(entityContext.ContextClass, contextName);
             contextName = _namer.UniqueContextName(contextName);
 
@@ -539,9 +539,13 @@ namespace EntityFrameworkCore.Generator
             return name.Pluralize(false);
         }
 
-        private string ContextName(string name)
+        private string ContextName(string name, string tableSchema)
         {
             var naming = _options.Data.Context.PropertyNaming;
+
+            if (_options.Project.AddSchemaToNamespace)
+                name = $"{tableSchema}{name}";
+
             if (naming == ContextNaming.Preserve)
                 return name;
 

--- a/src/EntityFrameworkCore.Generator.Core/Options/ProjectOptions.cs
+++ b/src/EntityFrameworkCore.Generator.Core/Options/ProjectOptions.cs
@@ -1,4 +1,6 @@
-﻿namespace EntityFrameworkCore.Generator.Options
+﻿using System.ComponentModel;
+
+namespace EntityFrameworkCore.Generator.Options
 {
     /// <summary>
     /// Project options
@@ -39,6 +41,11 @@
             get => GetProperty();
             set => SetProperty(value);
         }
-
+        
+        /// <summary>
+        /// If true add the schema to the namespace prevent naming conflicts
+        /// </summary>
+        [DefaultValue(false)]
+        public bool AddSchemaToNamespace { get; set; }
     }
 }

--- a/src/EntityFrameworkCore.Generator.Core/Templates/QueryExtensionTemplate.cs
+++ b/src/EntityFrameworkCore.Generator.Core/Templates/QueryExtensionTemplate.cs
@@ -26,6 +26,8 @@ namespace EntityFrameworkCore.Generator.Templates
             CodeBuilder.AppendLine();
 
             var extensionNamespace = Options.Data.Query.Namespace;
+            if (Options.Project.AddSchemaToNamespace)
+                extensionNamespace = $"{extensionNamespace}.{_entity.TableSchema}";
 
             CodeBuilder.AppendLine($"namespace {extensionNamespace}");
             CodeBuilder.AppendLine("{");


### PR DESCRIPTION
Support multiple database schemas without a number added to the model name or prefix the schema to the model (example: Person1 & Person2 or SchemaOnePerson & SchemaTwoPerson) 

Instead, add the database schema to the namespace. (example: SchemaOne.Person & SchemaTwo.Person)

In the DbContext, the schema name is prefixed in the variable name.

Original feature request: https://github.com/loresoft/EntityFrameworkCore.Generator/issues/29
