### PR TITLE
PrefixWithSchemaName improvements in ModelGenerator.cs

### DIFF
--- a/src/EntityFrameworkCore.Generator.Core/ModelGenerator.cs
+++ b/src/EntityFrameworkCore.Generator.Core/ModelGenerator.cs
@@ -579,7 +579,7 @@ namespace EntityFrameworkCore.Generator
             var className = tableName;
 
             if (_options.Data.Entity.PrefixWithSchemaName && tableSchema != null)
-                className = $"{tableSchema}{tableName}";
+                className = $"{tableSchema}_{tableName}";
 
             string legalName = ToLegalName(className);
 


### PR DESCRIPTION
When we use prefixWithSchemaName: true and in database (SQL Server) has lower underscore, when we run the generator the table and file names keep in unexpected format, for example:

current
- database table: dbo.vendor_address
- c#: DbovendorAddress

expected
- database table: dbo.vendor_address
- c#: DboVendorAddress

![pullrequest](https://user-images.githubusercontent.com/5017855/83576747-703f4880-a500-11ea-94f0-0f6c988d3bbc.png)
