### PR TITLE
[WIP] Introduce a C#9-based Source Generator based on EFG infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -243,3 +243,4 @@ _Pvt_Extensions
 *.GhostDoc.xml
 *.csv
 coverage.xml
+test/EntityFrameworkCore.Generator.Core.Tests/appsettings.local.json

--- a/EntityFrameworkCore.Generator.sln
+++ b/EntityFrameworkCore.Generator.sln
@@ -24,6 +24,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{A65FE81D-D0C1-48F1-9057-F3B79F6D39DC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EntityFrameworkCore.Generator.CS9Generator", "src\EntityFrameworkCore.Generator.CS9Generator\EntityFrameworkCore.Generator.CS9Generator.csproj", "{24307290-18C7-418A-92B1-4F65F82943B7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -70,12 +74,25 @@ Global
 		{C36914A2-9E52-4946-AD0E-8EF1EA52F38C}.Release|x64.Build.0 = Release|Any CPU
 		{C36914A2-9E52-4946-AD0E-8EF1EA52F38C}.Release|x86.ActiveCfg = Release|Any CPU
 		{C36914A2-9E52-4946-AD0E-8EF1EA52F38C}.Release|x86.Build.0 = Release|Any CPU
+		{24307290-18C7-418A-92B1-4F65F82943B7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{24307290-18C7-418A-92B1-4F65F82943B7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{24307290-18C7-418A-92B1-4F65F82943B7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{24307290-18C7-418A-92B1-4F65F82943B7}.Debug|x64.Build.0 = Debug|Any CPU
+		{24307290-18C7-418A-92B1-4F65F82943B7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{24307290-18C7-418A-92B1-4F65F82943B7}.Debug|x86.Build.0 = Debug|Any CPU
+		{24307290-18C7-418A-92B1-4F65F82943B7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{24307290-18C7-418A-92B1-4F65F82943B7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{24307290-18C7-418A-92B1-4F65F82943B7}.Release|x64.ActiveCfg = Release|Any CPU
+		{24307290-18C7-418A-92B1-4F65F82943B7}.Release|x64.Build.0 = Release|Any CPU
+		{24307290-18C7-418A-92B1-4F65F82943B7}.Release|x86.ActiveCfg = Release|Any CPU
+		{24307290-18C7-418A-92B1-4F65F82943B7}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{05E64176-6025-43C6-9F0F-2DD5E52EB325} = {3E4208F0-D270-45F4-BBBB-91DDA4050C1F}
+		{24307290-18C7-418A-92B1-4F65F82943B7} = {A65FE81D-D0C1-48F1-9057-F3B79F6D39DC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {1D52C3BA-3849-4790-810C-124F43DEDAFD}

--- a/sample/Tracker/Tracker.Core-CS9Gen/Data/Entities/Audit.cs
+++ b/sample/Tracker/Tracker.Core-CS9Gen/Data/Entities/Audit.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using Tracker.Core.Definitions;
+
+namespace Tracker.Core.Data.Entities
+{
+    /// <summary>
+    /// Entity class representing data for table 'Audit'.
+    /// </summary>
+    public partial class Audit : IHaveIdentifier
+    { }
+}

--- a/sample/Tracker/Tracker.Core-CS9Gen/Data/Entities/Priority.cs
+++ b/sample/Tracker/Tracker.Core-CS9Gen/Data/Entities/Priority.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using Tracker.Core.Definitions;
+
+namespace Tracker.Core.Data.Entities
+{
+    /// <summary>
+    /// Entity class representing data for table 'Priority'.
+    /// </summary>
+    public partial class Priority : IHaveIdentifier, ITrackCreated, ITrackUpdated
+    { }
+}

--- a/sample/Tracker/Tracker.Core-CS9Gen/Data/Entities/Role.cs
+++ b/sample/Tracker/Tracker.Core-CS9Gen/Data/Entities/Role.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using Tracker.Core.Definitions;
+
+namespace Tracker.Core.Data.Entities
+{
+    /// <summary>
+    /// Entity class representing data for table 'Role'.
+    /// </summary>
+    public partial class Role : IHaveIdentifier, ITrackCreated, ITrackUpdated
+    { }
+}

--- a/sample/Tracker/Tracker.Core-CS9Gen/Data/Entities/Status.cs
+++ b/sample/Tracker/Tracker.Core-CS9Gen/Data/Entities/Status.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using Tracker.Core.Definitions;
+
+namespace Tracker.Core.Data.Entities
+{
+    /// <summary>
+    /// Entity class representing data for table 'Status'.
+    /// </summary>
+    public partial class Status : IHaveIdentifier, ITrackCreated, ITrackUpdated
+    { }
+}

--- a/sample/Tracker/Tracker.Core-CS9Gen/Data/Entities/Task.cs
+++ b/sample/Tracker/Tracker.Core-CS9Gen/Data/Entities/Task.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using Tracker.Core.Definitions;
+
+namespace Tracker.Core.Data.Entities
+{
+    /// <summary>
+    /// Entity class representing data for table 'Task'.
+    /// </summary>
+    public partial class Task : IHaveIdentifier, ITrackCreated, ITrackUpdated
+        { }
+}

--- a/sample/Tracker/Tracker.Core-CS9Gen/Data/Entities/TaskExtended.cs
+++ b/sample/Tracker/Tracker.Core-CS9Gen/Data/Entities/TaskExtended.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using Tracker.Core.Definitions;
+
+namespace Tracker.Core.Data.Entities
+{
+    /// <summary>
+    /// Entity class representing data for table 'TaskExtended'.
+    /// </summary>
+    public partial class TaskExtended : ITrackCreated, ITrackUpdated
+    { }
+}

--- a/sample/Tracker/Tracker.Core-CS9Gen/Data/Entities/Tenant.cs
+++ b/sample/Tracker/Tracker.Core-CS9Gen/Data/Entities/Tenant.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using Tracker.Core.Definitions;
+
+namespace Tracker.Core.Data.Entities
+{
+    /// <summary>
+    /// Entity class representing data for table 'Tenant'.
+    /// </summary>
+    public partial class Tenant : IHaveIdentifier, ITrackCreated, ITrackUpdated
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Tenant"/> class.
+        /// </summary>
+        public Tenant()
+        {
+            #region Generated Constructor
+            Tasks = new HashSet<Task>();
+            #endregion
+        }
+
+        #region Generated Properties
+        /// <summary>
+        /// Gets or sets the property value representing column 'Id'.
+        /// </summary>
+        /// <value>
+        /// The property value representing column 'Id'.
+        /// </value>
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the property value representing column 'Name'.
+        /// </summary>
+        /// <value>
+        /// The property value representing column 'Name'.
+        /// </value>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the property value representing column 'Description'.
+        /// </summary>
+        /// <value>
+        /// The property value representing column 'Description'.
+        /// </value>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets the property value representing column 'IsActive'.
+        /// </summary>
+        /// <value>
+        /// The property value representing column 'IsActive'.
+        /// </value>
+        public bool IsActive { get; set; }
+
+        /// <summary>
+        /// Gets or sets the property value representing column 'Created'.
+        /// </summary>
+        /// <value>
+        /// The property value representing column 'Created'.
+        /// </value>
+        public DateTimeOffset Created { get; set; }
+
+        /// <summary>
+        /// Gets or sets the property value representing column 'CreatedBy'.
+        /// </summary>
+        /// <value>
+        /// The property value representing column 'CreatedBy'.
+        /// </value>
+        public string CreatedBy { get; set; }
+
+        /// <summary>
+        /// Gets or sets the property value representing column 'Updated'.
+        /// </summary>
+        /// <value>
+        /// The property value representing column 'Updated'.
+        /// </value>
+        public DateTimeOffset Updated { get; set; }
+
+        /// <summary>
+        /// Gets or sets the property value representing column 'UpdatedBy'.
+        /// </summary>
+        /// <value>
+        /// The property value representing column 'UpdatedBy'.
+        /// </value>
+        public string UpdatedBy { get; set; }
+
+        /// <summary>
+        /// Gets or sets the property value representing column 'RowVersion'.
+        /// </summary>
+        /// <value>
+        /// The property value representing column 'RowVersion'.
+        /// </value>
+        public Byte[] RowVersion { get; set; }
+
+        #endregion
+
+        #region Generated Relationships
+        /// <summary>
+        /// Gets or sets the navigation collection for entity <see cref="Task" />.
+        /// </summary>
+        /// <value>
+        /// The the navigation collection for entity <see cref="Task" />.
+        /// </value>
+        public virtual ICollection<Task> Tasks { get; set; }
+
+        #endregion
+
+    }
+}

--- a/sample/Tracker/Tracker.Core-CS9Gen/Data/Entities/User.cs
+++ b/sample/Tracker/Tracker.Core-CS9Gen/Data/Entities/User.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using Tracker.Core.Definitions;
+
+namespace Tracker.Core.Data.Entities
+{
+    /// <summary>
+    /// Entity class representing data for table 'User'.
+    /// </summary>
+    public partial class User : IHaveIdentifier, ITrackCreated, ITrackUpdated
+    { }
+}

--- a/sample/Tracker/Tracker.Core-CS9Gen/Data/Entities/UserLogin.cs
+++ b/sample/Tracker/Tracker.Core-CS9Gen/Data/Entities/UserLogin.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using Tracker.Core.Definitions;
+
+namespace Tracker.Core.Data.Entities
+{
+    /// <summary>
+    /// Entity class representing data for table 'UserLogin'.
+    /// </summary>
+    public partial class UserLogin : IHaveIdentifier, ITrackCreated, ITrackUpdated
+    { }
+}

--- a/sample/Tracker/Tracker.Core-CS9Gen/Data/Entities/UserRole.cs
+++ b/sample/Tracker/Tracker.Core-CS9Gen/Data/Entities/UserRole.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Collections.Generic;
+
+namespace Tracker.Core.Data.Entities
+{
+    /// <summary>
+    /// Entity class representing data for table 'UserRole'.
+    /// </summary>
+    public partial class UserRole
+    { }
+}

--- a/sample/Tracker/Tracker.Core-CS9Gen/Data/Mapping/TenantMap.cs
+++ b/sample/Tracker/Tracker.Core-CS9Gen/Data/Mapping/TenantMap.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore;
+
+namespace Tracker.Core.Data.Mapping
+{
+    /// <summary>
+    /// Allows configuration for an entity type <see cref="Tracker.Core.Data.Entities.Tenant" />
+    /// </summary>
+    public partial class TenantMap
+        : IEntityTypeConfiguration<Tracker.Core.Data.Entities.Tenant>
+    {
+        /// <summary>
+        /// Configures the entity of type <see cref="Tracker.Core.Data.Entities.Tenant" />
+        /// </summary>
+        /// <param name="builder">The builder to be used to configure the entity type.</param>
+        public void Configure(Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder<Tracker.Core.Data.Entities.Tenant> builder)
+        {
+            #region Generated Configure
+            // table
+            builder.ToTable("Tenant", "dbo");
+
+            // key
+            builder.HasKey(t => t.Id);
+
+            // properties
+            builder.Property(t => t.Id)
+                .IsRequired()
+                .HasColumnName("Id")
+                .HasColumnType("uniqueidentifier")
+                .HasDefaultValueSql("(newsequentialid())");
+
+            builder.Property(t => t.Name)
+                .IsRequired()
+                .HasColumnName("Name")
+                .HasColumnType("nvarchar(100)")
+                .HasMaxLength(100);
+
+            builder.Property(t => t.Description)
+                .HasColumnName("Description")
+                .HasColumnType("nvarchar(255)")
+                .HasMaxLength(255);
+
+            builder.Property(t => t.IsActive)
+                .IsRequired()
+                .HasColumnName("IsActive")
+                .HasColumnType("bit")
+                .HasDefaultValueSql("((1))");
+
+            builder.Property(t => t.Created)
+                .IsRequired()
+                .HasColumnName("Created")
+                .HasColumnType("datetimeoffset")
+                .HasDefaultValueSql("(sysutcdatetime())");
+
+            builder.Property(t => t.CreatedBy)
+                .HasColumnName("CreatedBy")
+                .HasColumnType("nvarchar(100)")
+                .HasMaxLength(100);
+
+            builder.Property(t => t.Updated)
+                .IsRequired()
+                .HasColumnName("Updated")
+                .HasColumnType("datetimeoffset")
+                .HasDefaultValueSql("(sysutcdatetime())");
+
+            builder.Property(t => t.UpdatedBy)
+                .HasColumnName("UpdatedBy")
+                .HasColumnType("nvarchar(100)")
+                .HasMaxLength(100);
+
+            builder.Property(t => t.RowVersion)
+                .IsRequired()
+                .IsRowVersion()
+                .HasColumnName("RowVersion")
+                .HasColumnType("rowversion")
+                .HasMaxLength(8)
+                .ValueGeneratedOnAddOrUpdate();
+
+            // relationships
+            #endregion
+        }
+
+        #region Generated Constants
+        /// <summary>Table Schema name constant for entity <see cref="Tracker.Core.Data.Entities.Tenant" /></summary>
+        public const string TableSchema = "dbo";
+        /// <summary>Table Name constant for entity <see cref="Tracker.Core.Data.Entities.Tenant" /></summary>
+        public const string TableName = "Tenant";
+
+        /// <summary>Column Name constant for property <see cref="Tracker.Core.Data.Entities.Tenant.Id" /></summary>
+        public const string ColumnId = "Id";
+        /// <summary>Column Name constant for property <see cref="Tracker.Core.Data.Entities.Tenant.Name" /></summary>
+        public const string ColumnName = "Name";
+        /// <summary>Column Name constant for property <see cref="Tracker.Core.Data.Entities.Tenant.Description" /></summary>
+        public const string ColumnDescription = "Description";
+        /// <summary>Column Name constant for property <see cref="Tracker.Core.Data.Entities.Tenant.IsActive" /></summary>
+        public const string ColumnIsActive = "IsActive";
+        /// <summary>Column Name constant for property <see cref="Tracker.Core.Data.Entities.Tenant.Created" /></summary>
+        public const string ColumnCreated = "Created";
+        /// <summary>Column Name constant for property <see cref="Tracker.Core.Data.Entities.Tenant.CreatedBy" /></summary>
+        public const string ColumnCreatedBy = "CreatedBy";
+        /// <summary>Column Name constant for property <see cref="Tracker.Core.Data.Entities.Tenant.Updated" /></summary>
+        public const string ColumnUpdated = "Updated";
+        /// <summary>Column Name constant for property <see cref="Tracker.Core.Data.Entities.Tenant.UpdatedBy" /></summary>
+        public const string ColumnUpdatedBy = "UpdatedBy";
+        /// <summary>Column Name constant for property <see cref="Tracker.Core.Data.Entities.Tenant.RowVersion" /></summary>
+        public const string ColumnRowVersion = "RowVersion";
+        #endregion
+    }
+}

--- a/sample/Tracker/Tracker.Core-CS9Gen/Data/Queries/TenantExtensions.cs
+++ b/sample/Tracker/Tracker.Core-CS9Gen/Data/Queries/TenantExtensions.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+
+namespace Tracker.Core.Data.Queries
+{
+    /// <summary>
+    /// Query extensions for entity <see cref="Tracker.Core.Data.Entities.Tenant" />.
+    /// </summary>
+    public static partial class TenantExtensions
+    {
+        #region Generated Extensions
+        /// <summary>
+        /// Gets an instance by the primary key.
+        /// </summary>
+        /// <param name="queryable">An <see cref="T:System.Linq.IQueryable`1" /> to filter.</param>
+        /// <param name="id">The value to filter by.</param>
+        /// <returns>An instance of <see cref="T:Tracker.Core.Data.Entities.Tenant"/> or null if not found.</returns>
+        public static Tracker.Core.Data.Entities.Tenant GetByKey(this IQueryable<Tracker.Core.Data.Entities.Tenant> queryable, Guid id)
+        {
+            if (queryable is DbSet<Tracker.Core.Data.Entities.Tenant> dbSet)
+                return dbSet.Find(id);
+
+            return queryable.FirstOrDefault(q => q.Id == id);
+        }
+
+        /// <summary>
+        /// Gets an instance by the primary key.
+        /// </summary>
+        /// <param name="queryable">An <see cref="T:System.Linq.IQueryable`1" /> to filter.</param>
+        /// <param name="id">The value to filter by.</param>
+        /// <returns>An instance of <see cref="T:Tracker.Core.Data.Entities.Tenant"/> or null if not found.</returns>
+        public static ValueTask<Tracker.Core.Data.Entities.Tenant> GetByKeyAsync(this IQueryable<Tracker.Core.Data.Entities.Tenant> queryable, Guid id)
+        {
+            if (queryable is DbSet<Tracker.Core.Data.Entities.Tenant> dbSet)
+                return dbSet.FindAsync(id);
+
+            var task = queryable.FirstOrDefaultAsync(q => q.Id == id);
+            return new ValueTask<Tracker.Core.Data.Entities.Tenant>(task);
+        }
+
+        #endregion
+
+    }
+}

--- a/sample/Tracker/Tracker.Core-CS9Gen/Data/TrackerContextBase.cs
+++ b/sample/Tracker/Tracker.Core-CS9Gen/Data/TrackerContextBase.cs
@@ -1,0 +1,20 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace Tracker.Core.Data
+{
+    public partial class TrackerContextBase : DbContext
+    {
+        public TrackerContextBase(DbContextOptions options)
+            : base(options)
+        {
+            
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            modelBuilder.ApplyConfiguration(new Tracker.Core.Data.Mapping.TenantMap());
+        }
+    }
+}

--- a/sample/Tracker/Tracker.Core-CS9Gen/Definitions/IHaveIdentifier.cs
+++ b/sample/Tracker/Tracker.Core-CS9Gen/Definitions/IHaveIdentifier.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Tracker.Core.Definitions
+{
+    public interface IHaveIdentifier
+    {
+        Guid Id { get; set; }
+    }
+}

--- a/sample/Tracker/Tracker.Core-CS9Gen/Definitions/ITrackConcurrency.cs
+++ b/sample/Tracker/Tracker.Core-CS9Gen/Definitions/ITrackConcurrency.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Tracker.Core.Definitions
+{
+    public interface ITrackConcurrency
+    {
+        string RowVersion { get; set; }
+    }
+}

--- a/sample/Tracker/Tracker.Core-CS9Gen/Definitions/ITrackCreated.cs
+++ b/sample/Tracker/Tracker.Core-CS9Gen/Definitions/ITrackCreated.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Tracker.Core.Definitions
+{
+    public interface ITrackCreated
+    {
+        DateTimeOffset Created { get; set; }
+        string CreatedBy { get; set; }
+    }
+}

--- a/sample/Tracker/Tracker.Core-CS9Gen/Definitions/ITrackDeleted.cs
+++ b/sample/Tracker/Tracker.Core-CS9Gen/Definitions/ITrackDeleted.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Tracker.Core.Definitions
+{
+    public interface ITrackDeleted
+    {
+        bool IsDeleted { get; set; }
+    }
+}

--- a/sample/Tracker/Tracker.Core-CS9Gen/Definitions/ITrackUpdated.cs
+++ b/sample/Tracker/Tracker.Core-CS9Gen/Definitions/ITrackUpdated.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Tracker.Core.Definitions
+{
+    public interface ITrackUpdated
+    {
+        DateTimeOffset Updated { get; set; }
+        string UpdatedBy { get; set; }
+    }
+}

--- a/sample/Tracker/Tracker.Core-CS9Gen/Domain/EntityCreateModel.cs
+++ b/sample/Tracker/Tracker.Core-CS9Gen/Domain/EntityCreateModel.cs
@@ -1,0 +1,19 @@
+using System;
+using Tracker.Core.Definitions;
+
+// ReSharper disable once CheckNamespace
+namespace Tracker.Core.Domain.Models
+{
+    public class EntityCreateModel : IHaveIdentifier, ITrackCreated, ITrackUpdated
+    {
+        public Guid Id { get; set; }
+
+        public DateTimeOffset Created { get; set; }
+
+        public string CreatedBy { get; set; }
+
+        public DateTimeOffset Updated { get; set; }
+
+        public string UpdatedBy { get; set; }
+    }
+}

--- a/sample/Tracker/Tracker.Core-CS9Gen/Domain/EntityReadModel.cs
+++ b/sample/Tracker/Tracker.Core-CS9Gen/Domain/EntityReadModel.cs
@@ -1,0 +1,21 @@
+using System;
+using Tracker.Core.Definitions;
+
+// ReSharper disable once CheckNamespace
+namespace Tracker.Core.Domain.Models
+{
+    public class EntityReadModel : IHaveIdentifier, ITrackCreated, ITrackUpdated, ITrackConcurrency
+    {
+        public Guid Id { get; set; }
+
+        public DateTimeOffset Created { get; set; } = DateTimeOffset.UtcNow;
+
+        public string CreatedBy { get; set; }
+
+        public DateTimeOffset Updated { get; set; } = DateTimeOffset.UtcNow;
+
+        public string UpdatedBy { get; set; }
+
+        public string RowVersion { get; set; }
+    }
+}

--- a/sample/Tracker/Tracker.Core-CS9Gen/Domain/EntityUpdateModel.cs
+++ b/sample/Tracker/Tracker.Core-CS9Gen/Domain/EntityUpdateModel.cs
@@ -1,0 +1,21 @@
+using System;
+using Tracker.Core.Definitions;
+
+// ReSharper disable once CheckNamespace
+namespace Tracker.Core.Domain.Models
+{
+    public class EntityUpdateModel : IHaveIdentifier, ITrackCreated, ITrackUpdated, ITrackConcurrency
+    {
+        public Guid Id { get; set; }
+
+        public DateTimeOffset Created { get; set; } = DateTimeOffset.UtcNow;
+
+        public string CreatedBy { get; set; }
+
+        public DateTimeOffset Updated { get; set; } = DateTimeOffset.UtcNow;
+
+        public string UpdatedBy { get; set; }
+
+        public string RowVersion { get; set; }
+    }
+}

--- a/sample/Tracker/Tracker.Core-CS9Gen/Domain/Tenant/Mapping/TenantProfile.cs
+++ b/sample/Tracker/Tracker.Core-CS9Gen/Domain/Tenant/Mapping/TenantProfile.cs
@@ -1,0 +1,30 @@
+using System;
+using AutoMapper;
+using Tracker.Core.Data.Entities;
+using Tracker.Core.Domain.Models;
+
+namespace Tracker.Core.Domain.Mapping
+{
+    /// <summary>
+    /// Mapper class for entity <see cref="Tenant"/> .
+    /// </summary>
+    public partial class TenantProfile
+        : Profile
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TenantProfile"/> class.
+        /// </summary>
+        public TenantProfile()
+        {
+            CreateMap<Tracker.Core.Data.Entities.Tenant, Tracker.Core.Domain.Models.TenantReadModel>();
+
+            CreateMap<Tracker.Core.Domain.Models.TenantCreateModel, Tracker.Core.Data.Entities.Tenant>();
+
+            CreateMap<Tracker.Core.Data.Entities.Tenant, Tracker.Core.Domain.Models.TenantUpdateModel>();
+
+            CreateMap<Tracker.Core.Domain.Models.TenantUpdateModel, Tracker.Core.Data.Entities.Tenant>();
+
+        }
+
+    }
+}

--- a/sample/Tracker/Tracker.Core-CS9Gen/Domain/Tenant/Models/TenantCreateModel.cs
+++ b/sample/Tracker/Tracker.Core-CS9Gen/Domain/Tenant/Models/TenantCreateModel.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+
+namespace Tracker.Core.Domain.Models
+{
+    /// <summary>
+    /// View Model class
+    /// </summary>
+    public partial class TenantCreateModel
+        : EntityCreateModel
+    {
+        #region Generated Properties
+        /// <summary>
+        /// Gets or sets the property value for 'Name'.
+        /// </summary>
+        /// <value>
+        /// The property value for 'Name'.
+        /// </value>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the property value for 'Description'.
+        /// </summary>
+        /// <value>
+        /// The property value for 'Description'.
+        /// </value>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets the property value for 'IsActive'.
+        /// </summary>
+        /// <value>
+        /// The property value for 'IsActive'.
+        /// </value>
+        public bool IsActive { get; set; }
+
+        #endregion
+
+    }
+}

--- a/sample/Tracker/Tracker.Core-CS9Gen/Domain/Tenant/Models/TenantReadModel.cs
+++ b/sample/Tracker/Tracker.Core-CS9Gen/Domain/Tenant/Models/TenantReadModel.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+
+namespace Tracker.Core.Domain.Models
+{
+    /// <summary>
+    /// View Model class
+    /// </summary>
+    public partial class TenantReadModel
+        : EntityReadModel
+    {
+        #region Generated Properties
+        /// <summary>
+        /// Gets or sets the property value for 'Name'.
+        /// </summary>
+        /// <value>
+        /// The property value for 'Name'.
+        /// </value>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the property value for 'Description'.
+        /// </summary>
+        /// <value>
+        /// The property value for 'Description'.
+        /// </value>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets the property value for 'IsActive'.
+        /// </summary>
+        /// <value>
+        /// The property value for 'IsActive'.
+        /// </value>
+        public bool IsActive { get; set; }
+
+        #endregion
+
+    }
+}

--- a/sample/Tracker/Tracker.Core-CS9Gen/Domain/Tenant/Models/TenantUpdateModel.cs
+++ b/sample/Tracker/Tracker.Core-CS9Gen/Domain/Tenant/Models/TenantUpdateModel.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+
+namespace Tracker.Core.Domain.Models
+{
+    /// <summary>
+    /// View Model class
+    /// </summary>
+    public partial class TenantUpdateModel
+        : EntityUpdateModel
+    {
+        #region Generated Properties
+        /// <summary>
+        /// Gets or sets the property value for 'Name'.
+        /// </summary>
+        /// <value>
+        /// The property value for 'Name'.
+        /// </value>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the property value for 'Description'.
+        /// </summary>
+        /// <value>
+        /// The property value for 'Description'.
+        /// </value>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Gets or sets the property value for 'IsActive'.
+        /// </summary>
+        /// <value>
+        /// The property value for 'IsActive'.
+        /// </value>
+        public bool IsActive { get; set; }
+
+        #endregion
+
+    }
+}

--- a/sample/Tracker/Tracker.Core-CS9Gen/Domain/Tenant/Validation/TenantCreateModelValidator.cs
+++ b/sample/Tracker/Tracker.Core-CS9Gen/Domain/Tenant/Validation/TenantCreateModelValidator.cs
@@ -1,0 +1,26 @@
+using System;
+using FluentValidation;
+using Tracker.Core.Domain.Models;
+
+namespace Tracker.Core.Domain.Validation
+{
+    /// <summary>
+    /// Validator class for <see cref="TenantCreateModel"/> .
+    /// </summary>
+    public partial class TenantCreateModelValidator
+        : AbstractValidator<TenantCreateModel>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TenantCreateModelValidator"/> class.
+        /// </summary>
+        public TenantCreateModelValidator()
+        {
+            #region Generated Constructor
+            RuleFor(p => p.Name).NotEmpty();
+            RuleFor(p => p.Name).MaximumLength(100);
+            RuleFor(p => p.Description).MaximumLength(255);
+            #endregion
+        }
+
+    }
+}

--- a/sample/Tracker/Tracker.Core-CS9Gen/Domain/Tenant/Validation/TenantUpdateModelValidator.cs
+++ b/sample/Tracker/Tracker.Core-CS9Gen/Domain/Tenant/Validation/TenantUpdateModelValidator.cs
@@ -1,0 +1,26 @@
+using System;
+using FluentValidation;
+using Tracker.Core.Domain.Models;
+
+namespace Tracker.Core.Domain.Validation
+{
+    /// <summary>
+    /// Validator class for <see cref="TenantUpdateModel"/> .
+    /// </summary>
+    public partial class TenantUpdateModelValidator
+        : AbstractValidator<TenantUpdateModel>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TenantUpdateModelValidator"/> class.
+        /// </summary>
+        public TenantUpdateModelValidator()
+        {
+            #region Generated Constructor
+            RuleFor(p => p.Name).NotEmpty();
+            RuleFor(p => p.Name).MaximumLength(100);
+            RuleFor(p => p.Description).MaximumLength(255);
+            #endregion
+        }
+
+    }
+}

--- a/sample/Tracker/Tracker.Core-CS9Gen/Script001.Tracker.Schema.sql
+++ b/sample/Tracker/Tracker.Core-CS9Gen/Script001.Tracker.Schema.sql
@@ -1,0 +1,299 @@
+﻿-- Schema
+-- IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = N'Tracker')
+-- EXEC sys.sp_executesql N'CREATE SCHEMA [dbo] AUTHORIZATION [dbo]'
+-- GO
+
+-- IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = N'Identity')
+-- EXEC sys.sp_executesql N'CREATE SCHEMA [dbo] AUTHORIZATION [dbo]'
+-- GO
+
+-- Tables
+IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[dbo].[Audit]') AND type in (N'U'))
+CREATE TABLE [dbo].[Audit] (
+    [Id] uniqueidentifier NOT NULL DEFAULT (NEWSEQUENTIALID()),
+    [Date] datetime NOT NULL,
+    [UserId] uniqueidentifier NULL,
+    [TaskId] uniqueidentifier NULL,
+    [Content] nvarchar(MAX) NOT NULL,
+    [Username] nvarchar(50) NOT NULL,
+    [Created] datetimeoffset NOT NULL DEFAULT (SYSUTCDATETIME()),
+    [CreatedBy] nvarchar(100) NULL,
+    [Updated] datetimeoffset NOT NULL DEFAULT (SYSUTCDATETIME()),
+    [UpdatedBy] nvarchar(100) NULL,
+    [RowVersion] rowversion NOT NULL,
+    CONSTRAINT [PK_Audit] PRIMARY KEY ([Id])
+);
+
+IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[dbo].[Priority]') AND type in (N'U'))
+CREATE TABLE [dbo].[Priority] (
+    [Id] uniqueidentifier NOT NULL DEFAULT (NEWSEQUENTIALID()),
+    [Name] nvarchar(100) NOT NULL,
+    [Description] nvarchar(255) NULL,
+    [DisplayOrder] int NOT NULL DEFAULT (0),
+    [IsActive] bit NOT NULL DEFAULT (1),
+    [Created] datetimeoffset NOT NULL DEFAULT (SYSUTCDATETIME()),
+    [CreatedBy] nvarchar(100) NULL,
+    [Updated] datetimeoffset NOT NULL DEFAULT (SYSUTCDATETIME()),
+    [UpdatedBy] nvarchar(100) NULL,
+    [RowVersion] rowversion NOT NULL,
+    CONSTRAINT [PK_Priority] PRIMARY KEY ([Id])
+);
+
+IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[dbo].[Role]') AND type in (N'U'))
+CREATE TABLE [dbo].[Role] (
+    [Id] uniqueidentifier NOT NULL DEFAULT (NEWSEQUENTIALID()),
+    [Name] nvarchar(256) NOT NULL,
+    [Description] nvarchar(MAX) NULL,
+    [Created] datetimeoffset NOT NULL DEFAULT (SYSUTCDATETIME()),
+    [CreatedBy] nvarchar(100) NULL,
+    [Updated] datetimeoffset NOT NULL DEFAULT (SYSUTCDATETIME()),
+    [UpdatedBy] nvarchar(100) NULL,
+    [RowVersion] rowversion NOT NULL,
+    CONSTRAINT [PK_Role] PRIMARY KEY ([Id])
+);
+
+IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[dbo].[Status]') AND type in (N'U'))
+CREATE TABLE [dbo].[Status] (
+    [Id] uniqueidentifier NOT NULL DEFAULT (NEWSEQUENTIALID()),
+    [Name] nvarchar(100) NOT NULL,
+    [Description] nvarchar(255) NULL,
+    [DisplayOrder] int NOT NULL DEFAULT (0),
+    [IsActive] bit NOT NULL DEFAULT (1),
+    [Created] datetimeoffset NOT NULL DEFAULT (SYSUTCDATETIME()),
+    [CreatedBy] nvarchar(100) NULL,
+    [Updated] datetimeoffset NOT NULL DEFAULT (SYSUTCDATETIME()),
+    [UpdatedBy] nvarchar(100) NULL,
+    [RowVersion] rowversion NOT NULL,
+    CONSTRAINT [PK_Status] PRIMARY KEY ([Id])
+);
+
+IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[dbo].[Task]') AND type in (N'U'))
+CREATE TABLE [dbo].[Task] (
+    [Id] uniqueidentifier NOT NULL DEFAULT (NEWSEQUENTIALID()),
+    [StatusId] uniqueidentifier NOT NULL,
+    [PriorityId] uniqueidentifier NULL,
+    [Title] nvarchar(255) NOT NULL,
+    [Description] nvarchar(MAX) NULL,
+    [StartDate] datetimeoffset NULL,
+    [DueDate] datetimeoffset NULL,
+    [CompleteDate] datetimeoffset NULL,
+    [AssignedId] uniqueidentifier NULL,
+    [Created] datetimeoffset NOT NULL DEFAULT (SYSUTCDATETIME()),
+    [CreatedBy] nvarchar(100) NULL,
+    [Updated] datetimeoffset NOT NULL DEFAULT (SYSUTCDATETIME()),
+    [UpdatedBy] nvarchar(100) NULL,
+    [RowVersion] rowversion NOT NULL,
+    CONSTRAINT [PK_Task] PRIMARY KEY ([Id])
+);
+
+IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[dbo].[TaskExtended]') AND type in (N'U'))
+CREATE TABLE [dbo].[TaskExtended] (
+    [TaskId] uniqueidentifier NOT NULL,
+    [UserAgent] nvarchar(MAX) NULL,
+    [Browser] nvarchar(256) NULL,
+    [OperatingSystem] nvarchar(256) NULL,
+    [Created] datetimeoffset NOT NULL DEFAULT (SYSUTCDATETIME()),
+    [CreatedBy] nvarchar(100) NULL,
+    [Updated] datetimeoffset NOT NULL DEFAULT (SYSUTCDATETIME()),
+    [UpdatedBy] nvarchar(100) NULL,
+    [RowVersion] rowversion NOT NULL,
+    CONSTRAINT [PK_TaskExtended] PRIMARY KEY ([TaskId])
+);
+
+IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[dbo].[User]') AND type in (N'U'))
+CREATE TABLE [dbo].[User] (
+    [Id] uniqueidentifier NOT NULL DEFAULT (NEWSEQUENTIALID()),
+    [EmailAddress] nvarchar(256) NOT NULL,
+    [IsEmailAddressConfirmed] bit NOT NULL DEFAULT (0),
+    [DisplayName] nvarchar(256) NOT NULL,
+    [PasswordHash] nvarchar(MAX) NULL,
+    [ResetHash] nvarchar(MAX) NULL,
+    [InviteHash] nvarchar(MAX) NULL,
+    [AccessFailedCount] int NOT NULL DEFAULT (0),
+    [LockoutEnabled] bit NOT NULL DEFAULT (0),
+    [LockoutEnd] datetimeoffset NULL,
+    [LastLogin] datetimeoffset NULL,
+    [IsDeleted] bit NOT NULL DEFAULT (0),
+    [Created] datetimeoffset NOT NULL DEFAULT (SYSUTCDATETIME()),
+    [CreatedBy] nvarchar(100) NULL,
+    [Updated] datetimeoffset NOT NULL DEFAULT (SYSUTCDATETIME()),
+    [UpdatedBy] nvarchar(100) NULL,
+    [RowVersion] rowversion NOT NULL,
+    CONSTRAINT [PK_User] PRIMARY KEY ([Id])
+);
+
+IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[dbo].[UserLogin]') AND type in (N'U'))
+CREATE TABLE [dbo].[UserLogin] (
+    [Id] uniqueidentifier NOT NULL DEFAULT (NEWSEQUENTIALID()),
+    [EmailAddress] nvarchar(256) NOT NULL,
+    [UserId] uniqueidentifier NULL,
+    [UserAgent] nvarchar(MAX) NULL,
+    [Browser] nvarchar(256) NULL,
+    [OperatingSystem] nvarchar(256) NULL,
+    [DeviceFamily] nvarchar(256) NULL,
+    [DeviceBrand] nvarchar(256) NULL,
+    [DeviceModel] nvarchar(256) NULL,
+    [IpAddress] nvarchar(50) NULL,
+    [IsSuccessful] bit NOT NULL DEFAULT (0),
+    [FailureMessage] nvarchar(256) NULL,
+    [Created] datetimeoffset NOT NULL DEFAULT (SYSUTCDATETIME()),
+    [CreatedBy] nvarchar(100) NULL,
+    [Updated] datetimeoffset NOT NULL DEFAULT (SYSUTCDATETIME()),
+    [UpdatedBy] nvarchar(100) NULL,
+    [RowVersion] rowversion NOT NULL,
+    CONSTRAINT [PK_UserLogin] PRIMARY KEY ([Id])
+);
+
+IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[dbo].[UserRole]') AND type in (N'U'))
+CREATE TABLE [dbo].[UserRole] (
+    [UserId] uniqueidentifier NOT NULL,
+    [RoleId] uniqueidentifier NOT NULL,
+    CONSTRAINT [PK_UserRole] PRIMARY KEY ([UserId], [RoleId])
+);
+
+
+-- Foreign Keys
+IF NOT EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'[dbo].[FK_Task_Priority_PriorityId]') AND parent_object_id = OBJECT_ID(N'[dbo].[Task]'))
+ALTER TABLE [dbo].[Task]
+    ADD CONSTRAINT [FK_Task_Priority_PriorityId] FOREIGN KEY ([PriorityId]) REFERENCES [dbo].[Priority] ([Id]);
+
+IF NOT EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'[dbo].[FK_Task_Status_StatusId]') AND parent_object_id = OBJECT_ID(N'[dbo].[Task]'))
+ALTER TABLE [dbo].[Task]
+    ADD CONSTRAINT [FK_Task_Status_StatusId] FOREIGN KEY ([StatusId]) REFERENCES [dbo].[Status] ([Id]);
+
+IF NOT EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'[dbo].[FK_Task_User_AssignedId]') AND parent_object_id = OBJECT_ID(N'[dbo].[Task]'))
+ALTER TABLE [dbo].[Task]
+    ADD CONSTRAINT [FK_Task_User_AssignedId] FOREIGN KEY ([AssignedId]) REFERENCES [dbo].[User] ([Id]);
+
+IF NOT EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'[dbo].[FK_TaskExtended_Task_TaskId]') AND parent_object_id = OBJECT_ID(N'[dbo].[TaskExtended]'))
+ALTER TABLE [dbo].[TaskExtended]
+    ADD CONSTRAINT [FK_TaskExtended_Task_TaskId] FOREIGN KEY ([TaskId]) REFERENCES [dbo].[Task] ([Id]);
+
+IF NOT EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'[dbo].[FK_UserLogin_User_UserId]') AND parent_object_id = OBJECT_ID(N'[dbo].[UserLogin]'))
+ALTER TABLE [dbo].[UserLogin]
+    ADD CONSTRAINT [FK_UserLogin_User_UserId] FOREIGN KEY ([UserId]) REFERENCES [dbo].[User] ([Id]);
+
+IF NOT EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'[dbo].[FK_UserRole_Role_RoleId]') AND parent_object_id = OBJECT_ID(N'[dbo].[UserRole]'))
+ALTER TABLE [dbo].[UserRole]
+    ADD CONSTRAINT [FK_UserRole_Role_RoleId] FOREIGN KEY ([RoleId]) REFERENCES [dbo].[Role] ([Id]);
+
+IF NOT EXISTS (SELECT * FROM sys.foreign_keys WHERE object_id = OBJECT_ID(N'[dbo].[FK_UserRole_User_UserId]') AND parent_object_id = OBJECT_ID(N'[dbo].[UserRole]'))
+ALTER TABLE [dbo].[UserRole]
+    ADD CONSTRAINT [FK_UserRole_User_UserId] FOREIGN KEY ([UserId]) REFERENCES [dbo].[User] ([Id]);
+
+
+-- Indexes
+IF NOT EXISTS (SELECT * FROM sys.indexes WHERE object_id = OBJECT_ID(N'[dbo].[Role]') AND name = N'UX_Role_Name')
+CREATE UNIQUE INDEX [UX_Role_Name]
+ON [dbo].[Role] ([Name]);
+
+IF NOT EXISTS (SELECT * FROM sys.indexes WHERE object_id = OBJECT_ID(N'[dbo].[Task]') AND name = N'IX_Task_AssignedId')
+CREATE INDEX [IX_Task_AssignedId]
+ON [dbo].[Task] ([AssignedId]);
+
+IF NOT EXISTS (SELECT * FROM sys.indexes WHERE object_id = OBJECT_ID(N'[dbo].[Task]') AND name = N'IX_Task_PriorityId')
+CREATE INDEX [IX_Task_PriorityId]
+ON [dbo].[Task] ([PriorityId]);
+
+IF NOT EXISTS (SELECT * FROM sys.indexes WHERE object_id = OBJECT_ID(N'[dbo].[Task]') AND name = N'IX_Task_StatusId')
+CREATE INDEX [IX_Task_StatusId]
+ON [dbo].[Task] ([StatusId]);
+
+IF NOT EXISTS (SELECT * FROM sys.indexes WHERE object_id = OBJECT_ID(N'[dbo].[User]') AND name = N'UX_User_EmailAddress')
+CREATE UNIQUE INDEX [UX_User_EmailAddress]
+ON [dbo].[User] ([EmailAddress]);
+
+IF NOT EXISTS (SELECT * FROM sys.indexes WHERE object_id = OBJECT_ID(N'[dbo].[UserLogin]') AND name = N'IX_UserLogin_EmailAddress')
+CREATE INDEX [IX_UserLogin_EmailAddress]
+ON [dbo].[UserLogin] ([EmailAddress]);
+
+IF NOT EXISTS (SELECT * FROM sys.indexes WHERE object_id = OBJECT_ID(N'[dbo].[UserLogin]') AND name = N'IX_UserLogin_UserId')
+CREATE INDEX [IX_UserLogin_UserId]
+ON [dbo].[UserLogin] ([UserId]);
+
+
+-- Table [dbo].[Priority] data
+
+MERGE INTO [dbo].[Priority] AS t
+USING 
+(
+    VALUES
+    ('DBF0E04F-04FB-E811-AA64-1E872CB6CB93', 'High', 'High Priority', 1, 1), 
+    ('DCF0E04F-04FB-E811-AA64-1E872CB6CB93', 'Normal', 'Normal Priority', 2, 1), 
+    ('784C7657-04FB-E811-AA64-1E872CB6CB93', 'Low', 'Low Priority', 3, 1)
+) 
+AS s
+([Id], [Name], [Description], [DisplayOrder], [IsActive])
+ON (t.[Id] = s.[Id])
+WHEN NOT MATCHED BY TARGET THEN 
+    INSERT ([Id], [Name], [Description], [DisplayOrder], [IsActive])
+    VALUES (s.[Id], s.[Name], s.[Description], s.[DisplayOrder], s.[IsActive])
+WHEN MATCHED THEN 
+    UPDATE SET t.[Name] = s.[Name], t.[Description] = s.[Description], t.[DisplayOrder] = s.[DisplayOrder], t.[IsActive] = s.[IsActive]
+OUTPUT $action as [Action];
+
+-- Table [dbo].[Status] data
+
+MERGE INTO [dbo].[Status] AS t
+USING 
+(
+    VALUES
+    ('CE002CD8-04FB-E811-AA64-1E872CB6CB93', 'Not Started', 'Not Starated', 1, 1), 
+    ('CF002CD8-04FB-E811-AA64-1E872CB6CB93', 'In Progress', 'In Progress', 2, 1), 
+    ('D0002CD8-04FB-E811-AA64-1E872CB6CB93', 'Completed', 'Completed', 3, 1), 
+    ('D1002CD8-04FB-E811-AA64-1E872CB6CB93', 'Blocked', 'Blocked', 4, 1), 
+    ('D2002CD8-04FB-E811-AA64-1E872CB6CB93', 'Deferred', 'Deferred', 5, 1), 
+    ('D3002CD8-04FB-E811-AA64-1E872CB6CB93', 'Done', 'Done', 6, 1)
+) 
+AS s
+([Id], [Name], [Description], [DisplayOrder], [IsActive])
+ON (t.[Id] = s.[Id])
+WHEN NOT MATCHED BY TARGET THEN 
+    INSERT ([Id], [Name], [Description], [DisplayOrder], [IsActive])
+    VALUES (s.[Id], s.[Name], s.[Description], s.[DisplayOrder], s.[IsActive])
+WHEN MATCHED THEN 
+    UPDATE SET t.[Name] = s.[Name], t.[Description] = s.[Description], t.[DisplayOrder] = s.[DisplayOrder], t.[IsActive] = s.[IsActive]
+OUTPUT $action as [Action];
+
+-- Table [dbo].[User] data
+
+MERGE INTO [dbo].[User] AS t
+USING 
+(
+    VALUES
+    ('83507c95-0744-e811-bd87-f8633fc30ac7', 'william.adama@battlestar.com', 1, 'William Adama'), 
+    ('490312a6-0744-e811-bd87-f8633fc30ac7', 'laura.roslin@battlestar.com', 1, 'Laura Roslin'), 
+    ('38da04bb-0744-e811-bd87-f8633fc30ac7', 'kara.thrace@battlestar.com', 1, 'Kara Thrace'), 
+    ('589d67c6-0744-e811-bd87-f8633fc30ac7', 'lee.adama@battlestar.com', 1, 'Lee Adama'), 
+    ('118b84d4-0744-e811-bd87-f8633fc30ac7', 'gaius.baltar@battlestar.com', 1, 'Gaius Baltar'), 
+    ('fa7515df-0744-e811-bd87-f8633fc30ac7', 'saul.tigh@battlestar.com', 1, 'Saul Tigh')
+) 
+AS s
+([Id], [EmailAddress], [IsEmailAddressConfirmed], [DisplayName])
+ON (t.[Id] = s.[Id])
+WHEN NOT MATCHED BY TARGET THEN 
+    INSERT ([Id], [EmailAddress], [IsEmailAddressConfirmed], [DisplayName])
+    VALUES (s.[Id], s.[EmailAddress], s.[IsEmailAddressConfirmed], s.[DisplayName])
+WHEN MATCHED THEN 
+    UPDATE SET t.[EmailAddress] = s.[EmailAddress], t.[IsEmailAddressConfirmed] = s.[IsEmailAddressConfirmed], t.[DisplayName] = s.[DisplayName]
+OUTPUT $action as [Action];
+
+-- Table [dbo].[Role] data
+
+MERGE INTO [dbo].[Role] AS t
+USING 
+(
+    VALUES
+    ('b2d78522-0944-e811-bd87-f8633fc30ac7', 'Administrator', 'Administrator'), 
+    ('b3d78522-0944-e811-bd87-f8633fc30ac7', 'Manager', 'Manager'), 
+    ('acbffa29-0944-e811-bd87-f8633fc30ac7', 'Member', 'Member')
+) 
+AS s
+([Id], [Name], [Description])
+ON (t.[Id] = s.[Id])
+WHEN NOT MATCHED BY TARGET THEN 
+    INSERT ([Id], [Name], [Description])
+    VALUES (s.[Id], s.[Name], s.[Description])
+WHEN MATCHED THEN 
+    UPDATE SET t.[Name] = s.[Name], t.[Description] = s.[Description]
+OUTPUT $action as [Action];

--- a/sample/Tracker/Tracker.Core-CS9Gen/Tracker.Core.csproj
+++ b/sample/Tracker/Tracker.Core-CS9Gen/Tracker.Core.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <AdditionalFiles Include="generation.efg.yml" />
+    <AdditionalFiles Include="*.efg.yml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sample/Tracker/Tracker.Core-CS9Gen/Tracker.Core.csproj
+++ b/sample/Tracker/Tracker.Core-CS9Gen/Tracker.Core.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <!-- This is only required if using a pre-release version of .NET 5.0 SDK -->
     <LangVersion>preview</LangVersion>
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sample/Tracker/Tracker.Core-CS9Gen/Tracker.Core.csproj
+++ b/sample/Tracker/Tracker.Core-CS9Gen/Tracker.Core.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <!-- This is only required if using a pre-release version of .NET 5.0 SDK -->
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AutoMapper" Version="9.0.0" />
+    <PackageReference Include="FluentValidation" Version="8.6.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="generation.efg.yml" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Data\Mapping\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\EntityFrameworkCore.Generator.CS9Generator\EntityFrameworkCore.Generator.CS9Generator.csproj"
+        OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+</Project>

--- a/sample/Tracker/Tracker.Core-CS9Gen/_efg/generation/dbmodel.cache.json
+++ b/sample/Tracker/Tracker.Core-CS9Gen/_efg/generation/dbmodel.cache.json
@@ -1,7 +1,7 @@
 {
   "$id": "1",
   "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseModel, Microsoft.EntityFrameworkCore.Relational",
-  "DatabaseName": "EFG_TrackerTest",
+  "DatabaseName": "Tracker",
   "DefaultSchema": "dbo",
   "Collation": "SQL_Latin1_General_CP1_CI_AS",
   "Tables": {
@@ -34,13 +34,13 @@
                 },
                 "Name": "Id",
                 "IsNullable": false,
-                "StoreType": "int",
-                "DefaultValueSql": null,
+                "StoreType": "uniqueidentifier",
+                "DefaultValueSql": "(newsequentialid())",
                 "ComputedColumnSql": null,
                 "IsStored": false,
                 "Comment": null,
                 "Collation": null,
-                "ValueGenerated": 1,
+                "ValueGenerated": null,
                 "$annotations": null
               }
             ]
@@ -78,7 +78,7 @@
               },
               "Name": "UserId",
               "IsNullable": true,
-              "StoreType": "int",
+              "StoreType": "uniqueidentifier",
               "DefaultValueSql": null,
               "ComputedColumnSql": null,
               "IsStored": false,
@@ -95,7 +95,7 @@
               },
               "Name": "TaskId",
               "IsNullable": true,
-              "StoreType": "int",
+              "StoreType": "uniqueidentifier",
               "DefaultValueSql": null,
               "ComputedColumnSql": null,
               "IsStored": false,
@@ -268,8 +268,8 @@
                 },
                 "Name": "Id",
                 "IsNullable": false,
-                "StoreType": "int",
-                "DefaultValueSql": null,
+                "StoreType": "uniqueidentifier",
+                "DefaultValueSql": "(newsequentialid())",
                 "ComputedColumnSql": null,
                 "IsStored": false,
                 "Comment": null,
@@ -486,7 +486,7 @@
                 "Name": "Id",
                 "IsNullable": false,
                 "StoreType": "uniqueidentifier",
-                "DefaultValueSql": null,
+                "DefaultValueSql": "(newsequentialid())",
                 "ComputedColumnSql": null,
                 "IsStored": false,
                 "Comment": null,
@@ -667,7 +667,7 @@
         "Database": {
           "$ref": "1"
         },
-        "Name": "SchemaVersions",
+        "Name": "Status",
         "Schema": "dbo",
         "Comment": null,
         "PrimaryKey": {
@@ -676,7 +676,7 @@
           "Table": {
             "$ref": "38"
           },
-          "Name": "PK_SchemaVersions_Id",
+          "Name": "PK_Status",
           "Columns": {
             "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
             "$values": [
@@ -688,13 +688,13 @@
                 },
                 "Name": "Id",
                 "IsNullable": false,
-                "StoreType": "int",
-                "DefaultValueSql": null,
+                "StoreType": "uniqueidentifier",
+                "DefaultValueSql": "(newsequentialid())",
                 "ComputedColumnSql": null,
                 "IsStored": false,
                 "Comment": null,
                 "Collation": null,
-                "ValueGenerated": 1,
+                "ValueGenerated": null,
                 "$annotations": null
               }
             ]
@@ -713,9 +713,9 @@
               "Table": {
                 "$ref": "38"
               },
-              "Name": "ScriptName",
+              "Name": "Name",
               "IsNullable": false,
-              "StoreType": "nvarchar(255)",
+              "StoreType": "nvarchar(100)",
               "DefaultValueSql": null,
               "ComputedColumnSql": null,
               "IsStored": false,
@@ -730,102 +730,6 @@
               "Table": {
                 "$ref": "38"
               },
-              "Name": "Applied",
-              "IsNullable": false,
-              "StoreType": "datetime",
-              "DefaultValueSql": null,
-              "ComputedColumnSql": null,
-              "IsStored": false,
-              "Comment": null,
-              "Collation": null,
-              "ValueGenerated": null,
-              "$annotations": null
-            }
-          ]
-        },
-        "UniqueConstraints": {
-          "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseUniqueConstraint, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
-          "$values": []
-        },
-        "Indexes": {
-          "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseIndex, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
-          "$values": []
-        },
-        "ForeignKeys": {
-          "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseForeignKey, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
-          "$values": []
-        },
-        "$annotations": null
-      },
-      {
-        "$id": "43",
-        "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseTable, Microsoft.EntityFrameworkCore.Relational",
-        "Database": {
-          "$ref": "1"
-        },
-        "Name": "Status",
-        "Schema": "dbo",
-        "Comment": null,
-        "PrimaryKey": {
-          "$id": "44",
-          "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabasePrimaryKey, Microsoft.EntityFrameworkCore.Relational",
-          "Table": {
-            "$ref": "43"
-          },
-          "Name": "PK_Status",
-          "Columns": {
-            "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
-            "$values": [
-              {
-                "$id": "45",
-                "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
-                "Table": {
-                  "$ref": "43"
-                },
-                "Name": "Id",
-                "IsNullable": false,
-                "StoreType": "int",
-                "DefaultValueSql": null,
-                "ComputedColumnSql": null,
-                "IsStored": false,
-                "Comment": null,
-                "Collation": null,
-                "ValueGenerated": null,
-                "$annotations": null
-              }
-            ]
-          },
-          "$annotations": null
-        },
-        "Columns": {
-          "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
-          "$values": [
-            {
-              "$ref": "45"
-            },
-            {
-              "$id": "46",
-              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
-              "Table": {
-                "$ref": "43"
-              },
-              "Name": "Name",
-              "IsNullable": false,
-              "StoreType": "nvarchar(100)",
-              "DefaultValueSql": null,
-              "ComputedColumnSql": null,
-              "IsStored": false,
-              "Comment": null,
-              "Collation": null,
-              "ValueGenerated": null,
-              "$annotations": null
-            },
-            {
-              "$id": "47",
-              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
-              "Table": {
-                "$ref": "43"
-              },
               "Name": "Description",
               "IsNullable": true,
               "StoreType": "nvarchar(255)",
@@ -838,10 +742,10 @@
               "$annotations": null
             },
             {
-              "$id": "48",
+              "$id": "43",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "43"
+                "$ref": "38"
               },
               "Name": "DisplayOrder",
               "IsNullable": false,
@@ -855,10 +759,10 @@
               "$annotations": null
             },
             {
-              "$id": "49",
+              "$id": "44",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "43"
+                "$ref": "38"
               },
               "Name": "IsActive",
               "IsNullable": false,
@@ -872,10 +776,10 @@
               "$annotations": null
             },
             {
-              "$id": "50",
+              "$id": "45",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "43"
+                "$ref": "38"
               },
               "Name": "Created",
               "IsNullable": false,
@@ -889,10 +793,10 @@
               "$annotations": null
             },
             {
-              "$id": "51",
+              "$id": "46",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "43"
+                "$ref": "38"
               },
               "Name": "CreatedBy",
               "IsNullable": true,
@@ -906,10 +810,10 @@
               "$annotations": null
             },
             {
-              "$id": "52",
+              "$id": "47",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "43"
+                "$ref": "38"
               },
               "Name": "Updated",
               "IsNullable": false,
@@ -923,10 +827,10 @@
               "$annotations": null
             },
             {
-              "$id": "53",
+              "$id": "48",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "43"
+                "$ref": "38"
               },
               "Name": "UpdatedBy",
               "IsNullable": true,
@@ -940,10 +844,10 @@
               "$annotations": null
             },
             {
-              "$id": "54",
+              "$id": "49",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "43"
+                "$ref": "38"
               },
               "Name": "RowVersion",
               "IsNullable": false,
@@ -975,7 +879,7 @@
         "$annotations": null
       },
       {
-        "$id": "55",
+        "$id": "50",
         "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseTable, Microsoft.EntityFrameworkCore.Relational",
         "Database": {
           "$ref": "1"
@@ -984,25 +888,25 @@
         "Schema": "dbo",
         "Comment": null,
         "PrimaryKey": {
-          "$id": "56",
+          "$id": "51",
           "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabasePrimaryKey, Microsoft.EntityFrameworkCore.Relational",
           "Table": {
-            "$ref": "55"
+            "$ref": "50"
           },
           "Name": "PK_Task",
           "Columns": {
             "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
             "$values": [
               {
-                "$id": "57",
+                "$id": "52",
                 "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
                 "Table": {
-                  "$ref": "55"
+                  "$ref": "50"
                 },
                 "Name": "Id",
                 "IsNullable": false,
                 "StoreType": "uniqueidentifier",
-                "DefaultValueSql": null,
+                "DefaultValueSql": "(newsequentialid())",
                 "ComputedColumnSql": null,
                 "IsStored": false,
                 "Comment": null,
@@ -1018,17 +922,17 @@
           "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
           "$values": [
             {
-              "$ref": "57"
+              "$ref": "52"
             },
             {
-              "$id": "58",
+              "$id": "53",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "55"
+                "$ref": "50"
               },
               "Name": "StatusId",
               "IsNullable": false,
-              "StoreType": "int",
+              "StoreType": "uniqueidentifier",
               "DefaultValueSql": null,
               "ComputedColumnSql": null,
               "IsStored": false,
@@ -1038,14 +942,14 @@
               "$annotations": null
             },
             {
-              "$id": "59",
+              "$id": "54",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "55"
+                "$ref": "50"
               },
               "Name": "PriorityId",
               "IsNullable": true,
-              "StoreType": "int",
+              "StoreType": "uniqueidentifier",
               "DefaultValueSql": null,
               "ComputedColumnSql": null,
               "IsStored": false,
@@ -1055,10 +959,10 @@
               "$annotations": null
             },
             {
-              "$id": "60",
+              "$id": "55",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "55"
+                "$ref": "50"
               },
               "Name": "Title",
               "IsNullable": false,
@@ -1072,10 +976,10 @@
               "$annotations": null
             },
             {
-              "$id": "61",
+              "$id": "56",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "55"
+                "$ref": "50"
               },
               "Name": "Description",
               "IsNullable": true,
@@ -1089,10 +993,10 @@
               "$annotations": null
             },
             {
-              "$id": "62",
+              "$id": "57",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "55"
+                "$ref": "50"
               },
               "Name": "StartDate",
               "IsNullable": true,
@@ -1106,10 +1010,10 @@
               "$annotations": null
             },
             {
-              "$id": "63",
+              "$id": "58",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "55"
+                "$ref": "50"
               },
               "Name": "DueDate",
               "IsNullable": true,
@@ -1123,10 +1027,10 @@
               "$annotations": null
             },
             {
-              "$id": "64",
+              "$id": "59",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "55"
+                "$ref": "50"
               },
               "Name": "CompleteDate",
               "IsNullable": true,
@@ -1140,10 +1044,10 @@
               "$annotations": null
             },
             {
-              "$id": "65",
+              "$id": "60",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "55"
+                "$ref": "50"
               },
               "Name": "AssignedId",
               "IsNullable": true,
@@ -1157,10 +1061,10 @@
               "$annotations": null
             },
             {
-              "$id": "66",
+              "$id": "61",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "55"
+                "$ref": "50"
               },
               "Name": "Created",
               "IsNullable": false,
@@ -1174,10 +1078,10 @@
               "$annotations": null
             },
             {
-              "$id": "67",
+              "$id": "62",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "55"
+                "$ref": "50"
               },
               "Name": "CreatedBy",
               "IsNullable": true,
@@ -1191,10 +1095,10 @@
               "$annotations": null
             },
             {
-              "$id": "68",
+              "$id": "63",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "55"
+                "$ref": "50"
               },
               "Name": "Updated",
               "IsNullable": false,
@@ -1208,10 +1112,10 @@
               "$annotations": null
             },
             {
-              "$id": "69",
+              "$id": "64",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "55"
+                "$ref": "50"
               },
               "Name": "UpdatedBy",
               "IsNullable": true,
@@ -1225,10 +1129,10 @@
               "$annotations": null
             },
             {
-              "$id": "70",
+              "$id": "65",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "55"
+                "$ref": "50"
               },
               "Name": "RowVersion",
               "IsNullable": false,
@@ -1253,17 +1157,17 @@
           "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseIndex, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
           "$values": [
             {
-              "$id": "71",
+              "$id": "66",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseIndex, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "55"
+                "$ref": "50"
               },
               "Name": "IX_Task_AssignedId",
               "Columns": {
                 "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
                 "$values": [
                   {
-                    "$ref": "65"
+                    "$ref": "60"
                   }
                 ]
               },
@@ -1272,17 +1176,17 @@
               "$annotations": null
             },
             {
-              "$id": "72",
+              "$id": "67",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseIndex, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "55"
+                "$ref": "50"
               },
               "Name": "IX_Task_PriorityId",
               "Columns": {
                 "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
                 "$values": [
                   {
-                    "$ref": "59"
+                    "$ref": "54"
                   }
                 ]
               },
@@ -1291,17 +1195,17 @@
               "$annotations": null
             },
             {
-              "$id": "73",
+              "$id": "68",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseIndex, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "55"
+                "$ref": "50"
               },
               "Name": "IX_Task_StatusId",
               "Columns": {
                 "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
                 "$values": [
                   {
-                    "$ref": "58"
+                    "$ref": "53"
                   }
                 ]
               },
@@ -1315,10 +1219,10 @@
           "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseForeignKey, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
           "$values": [
             {
-              "$id": "74",
+              "$id": "69",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseForeignKey, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "55"
+                "$ref": "50"
               },
               "PrincipalTable": {
                 "$ref": "15"
@@ -1327,7 +1231,7 @@
                 "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
                 "$values": [
                   {
-                    "$ref": "59"
+                    "$ref": "54"
                   }
                 ]
               },
@@ -1344,19 +1248,19 @@
               "$annotations": null
             },
             {
-              "$id": "75",
+              "$id": "70",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseForeignKey, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "55"
+                "$ref": "50"
               },
               "PrincipalTable": {
-                "$ref": "43"
+                "$ref": "38"
               },
               "Columns": {
                 "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
                 "$values": [
                   {
-                    "$ref": "58"
+                    "$ref": "53"
                   }
                 ]
               },
@@ -1364,7 +1268,7 @@
                 "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
                 "$values": [
                   {
-                    "$ref": "45"
+                    "$ref": "40"
                   }
                 ]
               },
@@ -1373,13 +1277,13 @@
               "$annotations": null
             },
             {
-              "$id": "76",
+              "$id": "71",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseForeignKey, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "55"
+                "$ref": "50"
               },
               "PrincipalTable": {
-                "$id": "77",
+                "$id": "72",
                 "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseTable, Microsoft.EntityFrameworkCore.Relational",
                 "Database": {
                   "$ref": "1"
@@ -1388,25 +1292,25 @@
                 "Schema": "dbo",
                 "Comment": null,
                 "PrimaryKey": {
-                  "$id": "78",
+                  "$id": "73",
                   "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabasePrimaryKey, Microsoft.EntityFrameworkCore.Relational",
                   "Table": {
-                    "$ref": "77"
+                    "$ref": "72"
                   },
                   "Name": "PK_User",
                   "Columns": {
                     "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
                     "$values": [
                       {
-                        "$id": "79",
+                        "$id": "74",
                         "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
                         "Table": {
-                          "$ref": "77"
+                          "$ref": "72"
                         },
                         "Name": "Id",
                         "IsNullable": false,
                         "StoreType": "uniqueidentifier",
-                        "DefaultValueSql": null,
+                        "DefaultValueSql": "(newsequentialid())",
                         "ComputedColumnSql": null,
                         "IsStored": false,
                         "Comment": null,
@@ -1422,13 +1326,13 @@
                   "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
                   "$values": [
                     {
-                      "$ref": "79"
+                      "$ref": "74"
                     },
                     {
-                      "$id": "80",
+                      "$id": "75",
                       "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
                       "Table": {
-                        "$ref": "77"
+                        "$ref": "72"
                       },
                       "Name": "EmailAddress",
                       "IsNullable": false,
@@ -1442,10 +1346,10 @@
                       "$annotations": null
                     },
                     {
-                      "$id": "81",
+                      "$id": "76",
                       "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
                       "Table": {
-                        "$ref": "77"
+                        "$ref": "72"
                       },
                       "Name": "IsEmailAddressConfirmed",
                       "IsNullable": false,
@@ -1459,10 +1363,10 @@
                       "$annotations": null
                     },
                     {
-                      "$id": "82",
+                      "$id": "77",
                       "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
                       "Table": {
-                        "$ref": "77"
+                        "$ref": "72"
                       },
                       "Name": "DisplayName",
                       "IsNullable": false,
@@ -1476,10 +1380,10 @@
                       "$annotations": null
                     },
                     {
-                      "$id": "83",
+                      "$id": "78",
                       "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
                       "Table": {
-                        "$ref": "77"
+                        "$ref": "72"
                       },
                       "Name": "PasswordHash",
                       "IsNullable": true,
@@ -1493,10 +1397,10 @@
                       "$annotations": null
                     },
                     {
-                      "$id": "84",
+                      "$id": "79",
                       "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
                       "Table": {
-                        "$ref": "77"
+                        "$ref": "72"
                       },
                       "Name": "ResetHash",
                       "IsNullable": true,
@@ -1510,10 +1414,10 @@
                       "$annotations": null
                     },
                     {
-                      "$id": "85",
+                      "$id": "80",
                       "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
                       "Table": {
-                        "$ref": "77"
+                        "$ref": "72"
                       },
                       "Name": "InviteHash",
                       "IsNullable": true,
@@ -1527,10 +1431,10 @@
                       "$annotations": null
                     },
                     {
-                      "$id": "86",
+                      "$id": "81",
                       "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
                       "Table": {
-                        "$ref": "77"
+                        "$ref": "72"
                       },
                       "Name": "AccessFailedCount",
                       "IsNullable": false,
@@ -1544,10 +1448,10 @@
                       "$annotations": null
                     },
                     {
-                      "$id": "87",
+                      "$id": "82",
                       "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
                       "Table": {
-                        "$ref": "77"
+                        "$ref": "72"
                       },
                       "Name": "LockoutEnabled",
                       "IsNullable": false,
@@ -1561,10 +1465,10 @@
                       "$annotations": null
                     },
                     {
-                      "$id": "88",
+                      "$id": "83",
                       "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
                       "Table": {
-                        "$ref": "77"
+                        "$ref": "72"
                       },
                       "Name": "LockoutEnd",
                       "IsNullable": true,
@@ -1578,10 +1482,10 @@
                       "$annotations": null
                     },
                     {
-                      "$id": "89",
+                      "$id": "84",
                       "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
                       "Table": {
-                        "$ref": "77"
+                        "$ref": "72"
                       },
                       "Name": "LastLogin",
                       "IsNullable": true,
@@ -1595,10 +1499,10 @@
                       "$annotations": null
                     },
                     {
-                      "$id": "90",
+                      "$id": "85",
                       "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
                       "Table": {
-                        "$ref": "77"
+                        "$ref": "72"
                       },
                       "Name": "IsDeleted",
                       "IsNullable": false,
@@ -1612,10 +1516,10 @@
                       "$annotations": null
                     },
                     {
-                      "$id": "91",
+                      "$id": "86",
                       "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
                       "Table": {
-                        "$ref": "77"
+                        "$ref": "72"
                       },
                       "Name": "Created",
                       "IsNullable": false,
@@ -1629,10 +1533,10 @@
                       "$annotations": null
                     },
                     {
-                      "$id": "92",
+                      "$id": "87",
                       "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
                       "Table": {
-                        "$ref": "77"
+                        "$ref": "72"
                       },
                       "Name": "CreatedBy",
                       "IsNullable": true,
@@ -1646,10 +1550,10 @@
                       "$annotations": null
                     },
                     {
-                      "$id": "93",
+                      "$id": "88",
                       "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
                       "Table": {
-                        "$ref": "77"
+                        "$ref": "72"
                       },
                       "Name": "Updated",
                       "IsNullable": false,
@@ -1663,10 +1567,10 @@
                       "$annotations": null
                     },
                     {
-                      "$id": "94",
+                      "$id": "89",
                       "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
                       "Table": {
-                        "$ref": "77"
+                        "$ref": "72"
                       },
                       "Name": "UpdatedBy",
                       "IsNullable": true,
@@ -1680,10 +1584,10 @@
                       "$annotations": null
                     },
                     {
-                      "$id": "95",
+                      "$id": "90",
                       "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
                       "Table": {
-                        "$ref": "77"
+                        "$ref": "72"
                       },
                       "Name": "RowVersion",
                       "IsNullable": false,
@@ -1708,17 +1612,17 @@
                   "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseIndex, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
                   "$values": [
                     {
-                      "$id": "96",
+                      "$id": "91",
                       "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseIndex, Microsoft.EntityFrameworkCore.Relational",
                       "Table": {
-                        "$ref": "77"
+                        "$ref": "72"
                       },
                       "Name": "UX_User_EmailAddress",
                       "Columns": {
                         "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
                         "$values": [
                           {
-                            "$ref": "80"
+                            "$ref": "75"
                           }
                         ]
                       },
@@ -1738,7 +1642,7 @@
                 "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
                 "$values": [
                   {
-                    "$ref": "65"
+                    "$ref": "60"
                   }
                 ]
               },
@@ -1746,7 +1650,7 @@
                 "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
                 "$values": [
                   {
-                    "$ref": "79"
+                    "$ref": "74"
                   }
                 ]
               },
@@ -1759,7 +1663,7 @@
         "$annotations": null
       },
       {
-        "$id": "97",
+        "$id": "92",
         "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseTable, Microsoft.EntityFrameworkCore.Relational",
         "Database": {
           "$ref": "1"
@@ -1768,20 +1672,20 @@
         "Schema": "dbo",
         "Comment": null,
         "PrimaryKey": {
-          "$id": "98",
+          "$id": "93",
           "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabasePrimaryKey, Microsoft.EntityFrameworkCore.Relational",
           "Table": {
-            "$ref": "97"
+            "$ref": "92"
           },
           "Name": "PK_TaskExtended",
           "Columns": {
             "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
             "$values": [
               {
-                "$id": "99",
+                "$id": "94",
                 "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
                 "Table": {
-                  "$ref": "97"
+                  "$ref": "92"
                 },
                 "Name": "TaskId",
                 "IsNullable": false,
@@ -1802,13 +1706,13 @@
           "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
           "$values": [
             {
-              "$ref": "99"
+              "$ref": "94"
             },
             {
-              "$id": "100",
+              "$id": "95",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "97"
+                "$ref": "92"
               },
               "Name": "UserAgent",
               "IsNullable": true,
@@ -1822,10 +1726,10 @@
               "$annotations": null
             },
             {
-              "$id": "101",
+              "$id": "96",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "97"
+                "$ref": "92"
               },
               "Name": "Browser",
               "IsNullable": true,
@@ -1839,10 +1743,10 @@
               "$annotations": null
             },
             {
-              "$id": "102",
+              "$id": "97",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "97"
+                "$ref": "92"
               },
               "Name": "OperatingSystem",
               "IsNullable": true,
@@ -1856,10 +1760,10 @@
               "$annotations": null
             },
             {
-              "$id": "103",
+              "$id": "98",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "97"
+                "$ref": "92"
               },
               "Name": "Created",
               "IsNullable": false,
@@ -1873,10 +1777,10 @@
               "$annotations": null
             },
             {
-              "$id": "104",
+              "$id": "99",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "97"
+                "$ref": "92"
               },
               "Name": "CreatedBy",
               "IsNullable": true,
@@ -1890,10 +1794,10 @@
               "$annotations": null
             },
             {
-              "$id": "105",
+              "$id": "100",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "97"
+                "$ref": "92"
               },
               "Name": "Updated",
               "IsNullable": false,
@@ -1907,10 +1811,10 @@
               "$annotations": null
             },
             {
-              "$id": "106",
+              "$id": "101",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "97"
+                "$ref": "92"
               },
               "Name": "UpdatedBy",
               "IsNullable": true,
@@ -1924,10 +1828,10 @@
               "$annotations": null
             },
             {
-              "$id": "107",
+              "$id": "102",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "97"
+                "$ref": "92"
               },
               "Name": "RowVersion",
               "IsNullable": false,
@@ -1956,19 +1860,19 @@
           "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseForeignKey, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
           "$values": [
             {
-              "$id": "108",
+              "$id": "103",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseForeignKey, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "97"
+                "$ref": "92"
               },
               "PrincipalTable": {
-                "$ref": "55"
+                "$ref": "50"
               },
               "Columns": {
                 "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
                 "$values": [
                   {
-                    "$ref": "99"
+                    "$ref": "94"
                   }
                 ]
               },
@@ -1976,7 +1880,7 @@
                 "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
                 "$values": [
                   {
-                    "$ref": "57"
+                    "$ref": "52"
                   }
                 ]
               },
@@ -1989,10 +1893,10 @@
         "$annotations": null
       },
       {
-        "$ref": "77"
+        "$ref": "72"
       },
       {
-        "$id": "109",
+        "$id": "104",
         "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseTable, Microsoft.EntityFrameworkCore.Relational",
         "Database": {
           "$ref": "1"
@@ -2001,25 +1905,25 @@
         "Schema": "dbo",
         "Comment": null,
         "PrimaryKey": {
-          "$id": "110",
+          "$id": "105",
           "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabasePrimaryKey, Microsoft.EntityFrameworkCore.Relational",
           "Table": {
-            "$ref": "109"
+            "$ref": "104"
           },
           "Name": "PK_UserLogin",
           "Columns": {
             "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
             "$values": [
               {
-                "$id": "111",
+                "$id": "106",
                 "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
                 "Table": {
-                  "$ref": "109"
+                  "$ref": "104"
                 },
                 "Name": "Id",
                 "IsNullable": false,
                 "StoreType": "uniqueidentifier",
-                "DefaultValueSql": null,
+                "DefaultValueSql": "(newsequentialid())",
                 "ComputedColumnSql": null,
                 "IsStored": false,
                 "Comment": null,
@@ -2035,13 +1939,13 @@
           "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
           "$values": [
             {
-              "$ref": "111"
+              "$ref": "106"
             },
             {
-              "$id": "112",
+              "$id": "107",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "109"
+                "$ref": "104"
               },
               "Name": "EmailAddress",
               "IsNullable": false,
@@ -2055,10 +1959,10 @@
               "$annotations": null
             },
             {
-              "$id": "113",
+              "$id": "108",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "109"
+                "$ref": "104"
               },
               "Name": "UserId",
               "IsNullable": true,
@@ -2072,10 +1976,10 @@
               "$annotations": null
             },
             {
-              "$id": "114",
+              "$id": "109",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "109"
+                "$ref": "104"
               },
               "Name": "UserAgent",
               "IsNullable": true,
@@ -2089,10 +1993,10 @@
               "$annotations": null
             },
             {
-              "$id": "115",
+              "$id": "110",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "109"
+                "$ref": "104"
               },
               "Name": "Browser",
               "IsNullable": true,
@@ -2106,10 +2010,10 @@
               "$annotations": null
             },
             {
-              "$id": "116",
+              "$id": "111",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "109"
+                "$ref": "104"
               },
               "Name": "OperatingSystem",
               "IsNullable": true,
@@ -2123,12 +2027,97 @@
               "$annotations": null
             },
             {
+              "$id": "112",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "104"
+              },
+              "Name": "DeviceFamily",
+              "IsNullable": true,
+              "StoreType": "nvarchar(256)",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "113",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "104"
+              },
+              "Name": "DeviceBrand",
+              "IsNullable": true,
+              "StoreType": "nvarchar(256)",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "114",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "104"
+              },
+              "Name": "DeviceModel",
+              "IsNullable": true,
+              "StoreType": "nvarchar(256)",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "115",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "104"
+              },
+              "Name": "IpAddress",
+              "IsNullable": true,
+              "StoreType": "nvarchar(50)",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "116",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "104"
+              },
+              "Name": "IsSuccessful",
+              "IsNullable": false,
+              "StoreType": "bit",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
               "$id": "117",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "109"
+                "$ref": "104"
               },
-              "Name": "DeviceFamily",
+              "Name": "FailureMessage",
               "IsNullable": true,
               "StoreType": "nvarchar(256)",
               "DefaultValueSql": null,
@@ -2143,92 +2132,7 @@
               "$id": "118",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "109"
-              },
-              "Name": "DeviceBrand",
-              "IsNullable": true,
-              "StoreType": "nvarchar(256)",
-              "DefaultValueSql": null,
-              "ComputedColumnSql": null,
-              "IsStored": false,
-              "Comment": null,
-              "Collation": null,
-              "ValueGenerated": null,
-              "$annotations": null
-            },
-            {
-              "$id": "119",
-              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
-              "Table": {
-                "$ref": "109"
-              },
-              "Name": "DeviceModel",
-              "IsNullable": true,
-              "StoreType": "nvarchar(256)",
-              "DefaultValueSql": null,
-              "ComputedColumnSql": null,
-              "IsStored": false,
-              "Comment": null,
-              "Collation": null,
-              "ValueGenerated": null,
-              "$annotations": null
-            },
-            {
-              "$id": "120",
-              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
-              "Table": {
-                "$ref": "109"
-              },
-              "Name": "IpAddress",
-              "IsNullable": true,
-              "StoreType": "nvarchar(50)",
-              "DefaultValueSql": null,
-              "ComputedColumnSql": null,
-              "IsStored": false,
-              "Comment": null,
-              "Collation": null,
-              "ValueGenerated": null,
-              "$annotations": null
-            },
-            {
-              "$id": "121",
-              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
-              "Table": {
-                "$ref": "109"
-              },
-              "Name": "IsSuccessful",
-              "IsNullable": false,
-              "StoreType": "bit",
-              "DefaultValueSql": null,
-              "ComputedColumnSql": null,
-              "IsStored": false,
-              "Comment": null,
-              "Collation": null,
-              "ValueGenerated": null,
-              "$annotations": null
-            },
-            {
-              "$id": "122",
-              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
-              "Table": {
-                "$ref": "109"
-              },
-              "Name": "FailureMessage",
-              "IsNullable": true,
-              "StoreType": "nvarchar(256)",
-              "DefaultValueSql": null,
-              "ComputedColumnSql": null,
-              "IsStored": false,
-              "Comment": null,
-              "Collation": null,
-              "ValueGenerated": null,
-              "$annotations": null
-            },
-            {
-              "$id": "123",
-              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
-              "Table": {
-                "$ref": "109"
+                "$ref": "104"
               },
               "Name": "Created",
               "IsNullable": false,
@@ -2242,10 +2146,10 @@
               "$annotations": null
             },
             {
-              "$id": "124",
+              "$id": "119",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "109"
+                "$ref": "104"
               },
               "Name": "CreatedBy",
               "IsNullable": true,
@@ -2259,10 +2163,10 @@
               "$annotations": null
             },
             {
-              "$id": "125",
+              "$id": "120",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "109"
+                "$ref": "104"
               },
               "Name": "Updated",
               "IsNullable": false,
@@ -2276,10 +2180,10 @@
               "$annotations": null
             },
             {
-              "$id": "126",
+              "$id": "121",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "109"
+                "$ref": "104"
               },
               "Name": "UpdatedBy",
               "IsNullable": true,
@@ -2293,10 +2197,10 @@
               "$annotations": null
             },
             {
-              "$id": "127",
+              "$id": "122",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "109"
+                "$ref": "104"
               },
               "Name": "RowVersion",
               "IsNullable": false,
@@ -2321,17 +2225,17 @@
           "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseIndex, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
           "$values": [
             {
-              "$id": "128",
+              "$id": "123",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseIndex, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "109"
+                "$ref": "104"
               },
               "Name": "IX_UserLogin_EmailAddress",
               "Columns": {
                 "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
                 "$values": [
                   {
-                    "$ref": "112"
+                    "$ref": "107"
                   }
                 ]
               },
@@ -2340,17 +2244,17 @@
               "$annotations": null
             },
             {
-              "$id": "129",
+              "$id": "124",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseIndex, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "109"
+                "$ref": "104"
               },
               "Name": "IX_UserLogin_UserId",
               "Columns": {
                 "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
                 "$values": [
                   {
-                    "$ref": "113"
+                    "$ref": "108"
                   }
                 ]
               },
@@ -2364,19 +2268,19 @@
           "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseForeignKey, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
           "$values": [
             {
-              "$id": "130",
+              "$id": "125",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseForeignKey, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "109"
+                "$ref": "104"
               },
               "PrincipalTable": {
-                "$ref": "77"
+                "$ref": "72"
               },
               "Columns": {
                 "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
                 "$values": [
                   {
-                    "$ref": "113"
+                    "$ref": "108"
                   }
                 ]
               },
@@ -2384,7 +2288,7 @@
                 "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
                 "$values": [
                   {
-                    "$ref": "79"
+                    "$ref": "74"
                   }
                 ]
               },
@@ -2397,7 +2301,7 @@
         "$annotations": null
       },
       {
-        "$id": "131",
+        "$id": "126",
         "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseTable, Microsoft.EntityFrameworkCore.Relational",
         "Database": {
           "$ref": "1"
@@ -2406,20 +2310,20 @@
         "Schema": "dbo",
         "Comment": null,
         "PrimaryKey": {
-          "$id": "132",
+          "$id": "127",
           "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabasePrimaryKey, Microsoft.EntityFrameworkCore.Relational",
           "Table": {
-            "$ref": "131"
+            "$ref": "126"
           },
           "Name": "PK_UserRole",
           "Columns": {
             "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
             "$values": [
               {
-                "$id": "133",
+                "$id": "128",
                 "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
                 "Table": {
-                  "$ref": "131"
+                  "$ref": "126"
                 },
                 "Name": "UserId",
                 "IsNullable": false,
@@ -2433,10 +2337,10 @@
                 "$annotations": null
               },
               {
-                "$id": "134",
+                "$id": "129",
                 "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
                 "Table": {
-                  "$ref": "131"
+                  "$ref": "126"
                 },
                 "Name": "RoleId",
                 "IsNullable": false,
@@ -2457,10 +2361,10 @@
           "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
           "$values": [
             {
-              "$ref": "133"
+              "$ref": "128"
             },
             {
-              "$ref": "134"
+              "$ref": "129"
             }
           ]
         },
@@ -2476,10 +2380,10 @@
           "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseForeignKey, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
           "$values": [
             {
-              "$id": "135",
+              "$id": "130",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseForeignKey, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "131"
+                "$ref": "126"
               },
               "PrincipalTable": {
                 "$ref": "27"
@@ -2488,7 +2392,7 @@
                 "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
                 "$values": [
                   {
-                    "$ref": "134"
+                    "$ref": "129"
                   }
                 ]
               },
@@ -2505,19 +2409,19 @@
               "$annotations": null
             },
             {
-              "$id": "136",
+              "$id": "131",
               "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseForeignKey, Microsoft.EntityFrameworkCore.Relational",
               "Table": {
-                "$ref": "131"
+                "$ref": "126"
               },
               "PrincipalTable": {
-                "$ref": "77"
+                "$ref": "72"
               },
               "Columns": {
                 "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
                 "$values": [
                   {
-                    "$ref": "133"
+                    "$ref": "128"
                   }
                 ]
               },
@@ -2525,7 +2429,7 @@
                 "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
                 "$values": [
                   {
-                    "$ref": "79"
+                    "$ref": "74"
                   }
                 ]
               },
@@ -2545,7 +2449,7 @@
   },
   "$annotations": {
     "EFG:Args": {
-      "$id": "137",
+      "$id": "132",
       "$type": "System.Collections.Generic.List`1[[System.String, System.Private.CoreLib]], System.Private.CoreLib",
       "$values": [
         "C:\\REDACTED\\EntityFrameworkCore.Generator\\src\\EntityFrameworkCore.Generator\\bin\\Debug\\netcoreapp3.1\\EntityFrameworkCore.Generator.dll",
@@ -2556,9 +2460,9 @@
     },
     "EFG:CLI": "C:\\REDACTED\\EntityFrameworkCore.Generator\\src\\EntityFrameworkCore.Generator\\bin\\Debug\\netcoreapp3.1\\EntityFrameworkCore.Generator.dll refresh -f .\\generation.efg.yml",
     "EFG:CLRVersion": "3.1.8",
-    "EFG:CreatedTime": "2020-12-14T21:21:18.3449412-05:00",
+    "EFG:CreatedTime": "2020-12-14T22:10:47.414169-05:00",
     "EFG:OS": {
-      "$id": "138",
+      "$id": "133",
       "$type": "System.OperatingSystem, System.Private.CoreLib",
       "Platform": 2,
       "ServicePack": "",

--- a/sample/Tracker/Tracker.Core-CS9Gen/_efg/generation/dbmodel.cache.json
+++ b/sample/Tracker/Tracker.Core-CS9Gen/_efg/generation/dbmodel.cache.json
@@ -1,0 +1,2569 @@
+{
+  "$id": "1",
+  "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseModel, Microsoft.EntityFrameworkCore.Relational",
+  "DatabaseName": "EFG_TrackerTest",
+  "DefaultSchema": "dbo",
+  "Collation": "SQL_Latin1_General_CP1_CI_AS",
+  "Tables": {
+    "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseTable, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+    "$values": [
+      {
+        "$id": "2",
+        "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseTable, Microsoft.EntityFrameworkCore.Relational",
+        "Database": {
+          "$ref": "1"
+        },
+        "Name": "Audit",
+        "Schema": "dbo",
+        "Comment": null,
+        "PrimaryKey": {
+          "$id": "3",
+          "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabasePrimaryKey, Microsoft.EntityFrameworkCore.Relational",
+          "Table": {
+            "$ref": "2"
+          },
+          "Name": "PK_Audit",
+          "Columns": {
+            "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+            "$values": [
+              {
+                "$id": "4",
+                "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+                "Table": {
+                  "$ref": "2"
+                },
+                "Name": "Id",
+                "IsNullable": false,
+                "StoreType": "int",
+                "DefaultValueSql": null,
+                "ComputedColumnSql": null,
+                "IsStored": false,
+                "Comment": null,
+                "Collation": null,
+                "ValueGenerated": 1,
+                "$annotations": null
+              }
+            ]
+          },
+          "$annotations": null
+        },
+        "Columns": {
+          "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+          "$values": [
+            {
+              "$ref": "4"
+            },
+            {
+              "$id": "5",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "2"
+              },
+              "Name": "Date",
+              "IsNullable": false,
+              "StoreType": "datetime",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "6",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "2"
+              },
+              "Name": "UserId",
+              "IsNullable": true,
+              "StoreType": "int",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "7",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "2"
+              },
+              "Name": "TaskId",
+              "IsNullable": true,
+              "StoreType": "int",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "8",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "2"
+              },
+              "Name": "Content",
+              "IsNullable": false,
+              "StoreType": "nvarchar(max)",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "9",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "2"
+              },
+              "Name": "Username",
+              "IsNullable": false,
+              "StoreType": "nvarchar(50)",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "10",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "2"
+              },
+              "Name": "Created",
+              "IsNullable": false,
+              "StoreType": "datetimeoffset",
+              "DefaultValueSql": "(sysutcdatetime())",
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "11",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "2"
+              },
+              "Name": "CreatedBy",
+              "IsNullable": true,
+              "StoreType": "nvarchar(100)",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "12",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "2"
+              },
+              "Name": "Updated",
+              "IsNullable": false,
+              "StoreType": "datetimeoffset",
+              "DefaultValueSql": "(sysutcdatetime())",
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "13",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "2"
+              },
+              "Name": "UpdatedBy",
+              "IsNullable": true,
+              "StoreType": "nvarchar(100)",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "14",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "2"
+              },
+              "Name": "RowVersion",
+              "IsNullable": false,
+              "StoreType": "rowversion",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": 3,
+              "$annotations": {
+                "ConcurrencyToken": true
+              }
+            }
+          ]
+        },
+        "UniqueConstraints": {
+          "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseUniqueConstraint, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+          "$values": []
+        },
+        "Indexes": {
+          "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseIndex, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+          "$values": []
+        },
+        "ForeignKeys": {
+          "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseForeignKey, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+          "$values": []
+        },
+        "$annotations": null
+      },
+      {
+        "$id": "15",
+        "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseTable, Microsoft.EntityFrameworkCore.Relational",
+        "Database": {
+          "$ref": "1"
+        },
+        "Name": "Priority",
+        "Schema": "dbo",
+        "Comment": null,
+        "PrimaryKey": {
+          "$id": "16",
+          "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabasePrimaryKey, Microsoft.EntityFrameworkCore.Relational",
+          "Table": {
+            "$ref": "15"
+          },
+          "Name": "PK_Priority",
+          "Columns": {
+            "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+            "$values": [
+              {
+                "$id": "17",
+                "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+                "Table": {
+                  "$ref": "15"
+                },
+                "Name": "Id",
+                "IsNullable": false,
+                "StoreType": "int",
+                "DefaultValueSql": null,
+                "ComputedColumnSql": null,
+                "IsStored": false,
+                "Comment": null,
+                "Collation": null,
+                "ValueGenerated": null,
+                "$annotations": null
+              }
+            ]
+          },
+          "$annotations": null
+        },
+        "Columns": {
+          "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+          "$values": [
+            {
+              "$ref": "17"
+            },
+            {
+              "$id": "18",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "15"
+              },
+              "Name": "Name",
+              "IsNullable": false,
+              "StoreType": "nvarchar(100)",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "19",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "15"
+              },
+              "Name": "Description",
+              "IsNullable": true,
+              "StoreType": "nvarchar(255)",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "20",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "15"
+              },
+              "Name": "DisplayOrder",
+              "IsNullable": false,
+              "StoreType": "int",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "21",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "15"
+              },
+              "Name": "IsActive",
+              "IsNullable": false,
+              "StoreType": "bit",
+              "DefaultValueSql": "((1))",
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "22",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "15"
+              },
+              "Name": "Created",
+              "IsNullable": false,
+              "StoreType": "datetimeoffset",
+              "DefaultValueSql": "(sysutcdatetime())",
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "23",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "15"
+              },
+              "Name": "CreatedBy",
+              "IsNullable": true,
+              "StoreType": "nvarchar(100)",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "24",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "15"
+              },
+              "Name": "Updated",
+              "IsNullable": false,
+              "StoreType": "datetimeoffset",
+              "DefaultValueSql": "(sysutcdatetime())",
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "25",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "15"
+              },
+              "Name": "UpdatedBy",
+              "IsNullable": true,
+              "StoreType": "nvarchar(100)",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "26",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "15"
+              },
+              "Name": "RowVersion",
+              "IsNullable": false,
+              "StoreType": "rowversion",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": 3,
+              "$annotations": {
+                "ConcurrencyToken": true
+              }
+            }
+          ]
+        },
+        "UniqueConstraints": {
+          "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseUniqueConstraint, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+          "$values": []
+        },
+        "Indexes": {
+          "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseIndex, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+          "$values": []
+        },
+        "ForeignKeys": {
+          "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseForeignKey, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+          "$values": []
+        },
+        "$annotations": null
+      },
+      {
+        "$id": "27",
+        "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseTable, Microsoft.EntityFrameworkCore.Relational",
+        "Database": {
+          "$ref": "1"
+        },
+        "Name": "Role",
+        "Schema": "dbo",
+        "Comment": null,
+        "PrimaryKey": {
+          "$id": "28",
+          "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabasePrimaryKey, Microsoft.EntityFrameworkCore.Relational",
+          "Table": {
+            "$ref": "27"
+          },
+          "Name": "PK_Role",
+          "Columns": {
+            "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+            "$values": [
+              {
+                "$id": "29",
+                "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+                "Table": {
+                  "$ref": "27"
+                },
+                "Name": "Id",
+                "IsNullable": false,
+                "StoreType": "uniqueidentifier",
+                "DefaultValueSql": null,
+                "ComputedColumnSql": null,
+                "IsStored": false,
+                "Comment": null,
+                "Collation": null,
+                "ValueGenerated": null,
+                "$annotations": null
+              }
+            ]
+          },
+          "$annotations": null
+        },
+        "Columns": {
+          "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+          "$values": [
+            {
+              "$ref": "29"
+            },
+            {
+              "$id": "30",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "27"
+              },
+              "Name": "Name",
+              "IsNullable": false,
+              "StoreType": "nvarchar(256)",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "31",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "27"
+              },
+              "Name": "Description",
+              "IsNullable": true,
+              "StoreType": "nvarchar(max)",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "32",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "27"
+              },
+              "Name": "Created",
+              "IsNullable": false,
+              "StoreType": "datetimeoffset",
+              "DefaultValueSql": "(sysutcdatetime())",
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "33",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "27"
+              },
+              "Name": "CreatedBy",
+              "IsNullable": true,
+              "StoreType": "nvarchar(100)",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "34",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "27"
+              },
+              "Name": "Updated",
+              "IsNullable": false,
+              "StoreType": "datetimeoffset",
+              "DefaultValueSql": "(sysutcdatetime())",
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "35",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "27"
+              },
+              "Name": "UpdatedBy",
+              "IsNullable": true,
+              "StoreType": "nvarchar(100)",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "36",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "27"
+              },
+              "Name": "RowVersion",
+              "IsNullable": false,
+              "StoreType": "rowversion",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": 3,
+              "$annotations": {
+                "ConcurrencyToken": true
+              }
+            }
+          ]
+        },
+        "UniqueConstraints": {
+          "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseUniqueConstraint, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+          "$values": []
+        },
+        "Indexes": {
+          "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseIndex, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+          "$values": [
+            {
+              "$id": "37",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseIndex, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "27"
+              },
+              "Name": "UX_Role_Name",
+              "Columns": {
+                "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+                "$values": [
+                  {
+                    "$ref": "30"
+                  }
+                ]
+              },
+              "IsUnique": true,
+              "Filter": null,
+              "$annotations": null
+            }
+          ]
+        },
+        "ForeignKeys": {
+          "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseForeignKey, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+          "$values": []
+        },
+        "$annotations": null
+      },
+      {
+        "$id": "38",
+        "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseTable, Microsoft.EntityFrameworkCore.Relational",
+        "Database": {
+          "$ref": "1"
+        },
+        "Name": "SchemaVersions",
+        "Schema": "dbo",
+        "Comment": null,
+        "PrimaryKey": {
+          "$id": "39",
+          "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabasePrimaryKey, Microsoft.EntityFrameworkCore.Relational",
+          "Table": {
+            "$ref": "38"
+          },
+          "Name": "PK_SchemaVersions_Id",
+          "Columns": {
+            "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+            "$values": [
+              {
+                "$id": "40",
+                "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+                "Table": {
+                  "$ref": "38"
+                },
+                "Name": "Id",
+                "IsNullable": false,
+                "StoreType": "int",
+                "DefaultValueSql": null,
+                "ComputedColumnSql": null,
+                "IsStored": false,
+                "Comment": null,
+                "Collation": null,
+                "ValueGenerated": 1,
+                "$annotations": null
+              }
+            ]
+          },
+          "$annotations": null
+        },
+        "Columns": {
+          "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+          "$values": [
+            {
+              "$ref": "40"
+            },
+            {
+              "$id": "41",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "38"
+              },
+              "Name": "ScriptName",
+              "IsNullable": false,
+              "StoreType": "nvarchar(255)",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "42",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "38"
+              },
+              "Name": "Applied",
+              "IsNullable": false,
+              "StoreType": "datetime",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            }
+          ]
+        },
+        "UniqueConstraints": {
+          "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseUniqueConstraint, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+          "$values": []
+        },
+        "Indexes": {
+          "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseIndex, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+          "$values": []
+        },
+        "ForeignKeys": {
+          "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseForeignKey, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+          "$values": []
+        },
+        "$annotations": null
+      },
+      {
+        "$id": "43",
+        "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseTable, Microsoft.EntityFrameworkCore.Relational",
+        "Database": {
+          "$ref": "1"
+        },
+        "Name": "Status",
+        "Schema": "dbo",
+        "Comment": null,
+        "PrimaryKey": {
+          "$id": "44",
+          "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabasePrimaryKey, Microsoft.EntityFrameworkCore.Relational",
+          "Table": {
+            "$ref": "43"
+          },
+          "Name": "PK_Status",
+          "Columns": {
+            "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+            "$values": [
+              {
+                "$id": "45",
+                "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+                "Table": {
+                  "$ref": "43"
+                },
+                "Name": "Id",
+                "IsNullable": false,
+                "StoreType": "int",
+                "DefaultValueSql": null,
+                "ComputedColumnSql": null,
+                "IsStored": false,
+                "Comment": null,
+                "Collation": null,
+                "ValueGenerated": null,
+                "$annotations": null
+              }
+            ]
+          },
+          "$annotations": null
+        },
+        "Columns": {
+          "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+          "$values": [
+            {
+              "$ref": "45"
+            },
+            {
+              "$id": "46",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "43"
+              },
+              "Name": "Name",
+              "IsNullable": false,
+              "StoreType": "nvarchar(100)",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "47",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "43"
+              },
+              "Name": "Description",
+              "IsNullable": true,
+              "StoreType": "nvarchar(255)",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "48",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "43"
+              },
+              "Name": "DisplayOrder",
+              "IsNullable": false,
+              "StoreType": "int",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "49",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "43"
+              },
+              "Name": "IsActive",
+              "IsNullable": false,
+              "StoreType": "bit",
+              "DefaultValueSql": "((1))",
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "50",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "43"
+              },
+              "Name": "Created",
+              "IsNullable": false,
+              "StoreType": "datetimeoffset",
+              "DefaultValueSql": "(sysutcdatetime())",
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "51",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "43"
+              },
+              "Name": "CreatedBy",
+              "IsNullable": true,
+              "StoreType": "nvarchar(100)",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "52",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "43"
+              },
+              "Name": "Updated",
+              "IsNullable": false,
+              "StoreType": "datetimeoffset",
+              "DefaultValueSql": "(sysutcdatetime())",
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "53",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "43"
+              },
+              "Name": "UpdatedBy",
+              "IsNullable": true,
+              "StoreType": "nvarchar(100)",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "54",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "43"
+              },
+              "Name": "RowVersion",
+              "IsNullable": false,
+              "StoreType": "rowversion",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": 3,
+              "$annotations": {
+                "ConcurrencyToken": true
+              }
+            }
+          ]
+        },
+        "UniqueConstraints": {
+          "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseUniqueConstraint, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+          "$values": []
+        },
+        "Indexes": {
+          "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseIndex, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+          "$values": []
+        },
+        "ForeignKeys": {
+          "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseForeignKey, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+          "$values": []
+        },
+        "$annotations": null
+      },
+      {
+        "$id": "55",
+        "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseTable, Microsoft.EntityFrameworkCore.Relational",
+        "Database": {
+          "$ref": "1"
+        },
+        "Name": "Task",
+        "Schema": "dbo",
+        "Comment": null,
+        "PrimaryKey": {
+          "$id": "56",
+          "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabasePrimaryKey, Microsoft.EntityFrameworkCore.Relational",
+          "Table": {
+            "$ref": "55"
+          },
+          "Name": "PK_Task",
+          "Columns": {
+            "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+            "$values": [
+              {
+                "$id": "57",
+                "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+                "Table": {
+                  "$ref": "55"
+                },
+                "Name": "Id",
+                "IsNullable": false,
+                "StoreType": "uniqueidentifier",
+                "DefaultValueSql": null,
+                "ComputedColumnSql": null,
+                "IsStored": false,
+                "Comment": null,
+                "Collation": null,
+                "ValueGenerated": null,
+                "$annotations": null
+              }
+            ]
+          },
+          "$annotations": null
+        },
+        "Columns": {
+          "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+          "$values": [
+            {
+              "$ref": "57"
+            },
+            {
+              "$id": "58",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "55"
+              },
+              "Name": "StatusId",
+              "IsNullable": false,
+              "StoreType": "int",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "59",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "55"
+              },
+              "Name": "PriorityId",
+              "IsNullable": true,
+              "StoreType": "int",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "60",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "55"
+              },
+              "Name": "Title",
+              "IsNullable": false,
+              "StoreType": "nvarchar(255)",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "61",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "55"
+              },
+              "Name": "Description",
+              "IsNullable": true,
+              "StoreType": "nvarchar(max)",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "62",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "55"
+              },
+              "Name": "StartDate",
+              "IsNullable": true,
+              "StoreType": "datetimeoffset",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "63",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "55"
+              },
+              "Name": "DueDate",
+              "IsNullable": true,
+              "StoreType": "datetimeoffset",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "64",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "55"
+              },
+              "Name": "CompleteDate",
+              "IsNullable": true,
+              "StoreType": "datetimeoffset",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "65",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "55"
+              },
+              "Name": "AssignedId",
+              "IsNullable": true,
+              "StoreType": "uniqueidentifier",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "66",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "55"
+              },
+              "Name": "Created",
+              "IsNullable": false,
+              "StoreType": "datetimeoffset",
+              "DefaultValueSql": "(sysutcdatetime())",
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "67",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "55"
+              },
+              "Name": "CreatedBy",
+              "IsNullable": true,
+              "StoreType": "nvarchar(100)",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "68",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "55"
+              },
+              "Name": "Updated",
+              "IsNullable": false,
+              "StoreType": "datetimeoffset",
+              "DefaultValueSql": "(sysutcdatetime())",
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "69",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "55"
+              },
+              "Name": "UpdatedBy",
+              "IsNullable": true,
+              "StoreType": "nvarchar(100)",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "70",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "55"
+              },
+              "Name": "RowVersion",
+              "IsNullable": false,
+              "StoreType": "rowversion",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": 3,
+              "$annotations": {
+                "ConcurrencyToken": true
+              }
+            }
+          ]
+        },
+        "UniqueConstraints": {
+          "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseUniqueConstraint, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+          "$values": []
+        },
+        "Indexes": {
+          "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseIndex, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+          "$values": [
+            {
+              "$id": "71",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseIndex, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "55"
+              },
+              "Name": "IX_Task_AssignedId",
+              "Columns": {
+                "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+                "$values": [
+                  {
+                    "$ref": "65"
+                  }
+                ]
+              },
+              "IsUnique": false,
+              "Filter": null,
+              "$annotations": null
+            },
+            {
+              "$id": "72",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseIndex, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "55"
+              },
+              "Name": "IX_Task_PriorityId",
+              "Columns": {
+                "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+                "$values": [
+                  {
+                    "$ref": "59"
+                  }
+                ]
+              },
+              "IsUnique": false,
+              "Filter": null,
+              "$annotations": null
+            },
+            {
+              "$id": "73",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseIndex, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "55"
+              },
+              "Name": "IX_Task_StatusId",
+              "Columns": {
+                "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+                "$values": [
+                  {
+                    "$ref": "58"
+                  }
+                ]
+              },
+              "IsUnique": false,
+              "Filter": null,
+              "$annotations": null
+            }
+          ]
+        },
+        "ForeignKeys": {
+          "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseForeignKey, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+          "$values": [
+            {
+              "$id": "74",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseForeignKey, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "55"
+              },
+              "PrincipalTable": {
+                "$ref": "15"
+              },
+              "Columns": {
+                "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+                "$values": [
+                  {
+                    "$ref": "59"
+                  }
+                ]
+              },
+              "PrincipalColumns": {
+                "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+                "$values": [
+                  {
+                    "$ref": "17"
+                  }
+                ]
+              },
+              "Name": "FK_Task_Priority_PriorityId",
+              "OnDelete": 0,
+              "$annotations": null
+            },
+            {
+              "$id": "75",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseForeignKey, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "55"
+              },
+              "PrincipalTable": {
+                "$ref": "43"
+              },
+              "Columns": {
+                "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+                "$values": [
+                  {
+                    "$ref": "58"
+                  }
+                ]
+              },
+              "PrincipalColumns": {
+                "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+                "$values": [
+                  {
+                    "$ref": "45"
+                  }
+                ]
+              },
+              "Name": "FK_Task_Status_StatusId",
+              "OnDelete": 0,
+              "$annotations": null
+            },
+            {
+              "$id": "76",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseForeignKey, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "55"
+              },
+              "PrincipalTable": {
+                "$id": "77",
+                "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseTable, Microsoft.EntityFrameworkCore.Relational",
+                "Database": {
+                  "$ref": "1"
+                },
+                "Name": "User",
+                "Schema": "dbo",
+                "Comment": null,
+                "PrimaryKey": {
+                  "$id": "78",
+                  "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabasePrimaryKey, Microsoft.EntityFrameworkCore.Relational",
+                  "Table": {
+                    "$ref": "77"
+                  },
+                  "Name": "PK_User",
+                  "Columns": {
+                    "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+                    "$values": [
+                      {
+                        "$id": "79",
+                        "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+                        "Table": {
+                          "$ref": "77"
+                        },
+                        "Name": "Id",
+                        "IsNullable": false,
+                        "StoreType": "uniqueidentifier",
+                        "DefaultValueSql": null,
+                        "ComputedColumnSql": null,
+                        "IsStored": false,
+                        "Comment": null,
+                        "Collation": null,
+                        "ValueGenerated": null,
+                        "$annotations": null
+                      }
+                    ]
+                  },
+                  "$annotations": null
+                },
+                "Columns": {
+                  "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+                  "$values": [
+                    {
+                      "$ref": "79"
+                    },
+                    {
+                      "$id": "80",
+                      "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+                      "Table": {
+                        "$ref": "77"
+                      },
+                      "Name": "EmailAddress",
+                      "IsNullable": false,
+                      "StoreType": "nvarchar(256)",
+                      "DefaultValueSql": null,
+                      "ComputedColumnSql": null,
+                      "IsStored": false,
+                      "Comment": null,
+                      "Collation": null,
+                      "ValueGenerated": null,
+                      "$annotations": null
+                    },
+                    {
+                      "$id": "81",
+                      "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+                      "Table": {
+                        "$ref": "77"
+                      },
+                      "Name": "IsEmailAddressConfirmed",
+                      "IsNullable": false,
+                      "StoreType": "bit",
+                      "DefaultValueSql": null,
+                      "ComputedColumnSql": null,
+                      "IsStored": false,
+                      "Comment": null,
+                      "Collation": null,
+                      "ValueGenerated": null,
+                      "$annotations": null
+                    },
+                    {
+                      "$id": "82",
+                      "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+                      "Table": {
+                        "$ref": "77"
+                      },
+                      "Name": "DisplayName",
+                      "IsNullable": false,
+                      "StoreType": "nvarchar(256)",
+                      "DefaultValueSql": null,
+                      "ComputedColumnSql": null,
+                      "IsStored": false,
+                      "Comment": null,
+                      "Collation": null,
+                      "ValueGenerated": null,
+                      "$annotations": null
+                    },
+                    {
+                      "$id": "83",
+                      "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+                      "Table": {
+                        "$ref": "77"
+                      },
+                      "Name": "PasswordHash",
+                      "IsNullable": true,
+                      "StoreType": "nvarchar(max)",
+                      "DefaultValueSql": null,
+                      "ComputedColumnSql": null,
+                      "IsStored": false,
+                      "Comment": null,
+                      "Collation": null,
+                      "ValueGenerated": null,
+                      "$annotations": null
+                    },
+                    {
+                      "$id": "84",
+                      "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+                      "Table": {
+                        "$ref": "77"
+                      },
+                      "Name": "ResetHash",
+                      "IsNullable": true,
+                      "StoreType": "nvarchar(max)",
+                      "DefaultValueSql": null,
+                      "ComputedColumnSql": null,
+                      "IsStored": false,
+                      "Comment": null,
+                      "Collation": null,
+                      "ValueGenerated": null,
+                      "$annotations": null
+                    },
+                    {
+                      "$id": "85",
+                      "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+                      "Table": {
+                        "$ref": "77"
+                      },
+                      "Name": "InviteHash",
+                      "IsNullable": true,
+                      "StoreType": "nvarchar(max)",
+                      "DefaultValueSql": null,
+                      "ComputedColumnSql": null,
+                      "IsStored": false,
+                      "Comment": null,
+                      "Collation": null,
+                      "ValueGenerated": null,
+                      "$annotations": null
+                    },
+                    {
+                      "$id": "86",
+                      "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+                      "Table": {
+                        "$ref": "77"
+                      },
+                      "Name": "AccessFailedCount",
+                      "IsNullable": false,
+                      "StoreType": "int",
+                      "DefaultValueSql": null,
+                      "ComputedColumnSql": null,
+                      "IsStored": false,
+                      "Comment": null,
+                      "Collation": null,
+                      "ValueGenerated": null,
+                      "$annotations": null
+                    },
+                    {
+                      "$id": "87",
+                      "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+                      "Table": {
+                        "$ref": "77"
+                      },
+                      "Name": "LockoutEnabled",
+                      "IsNullable": false,
+                      "StoreType": "bit",
+                      "DefaultValueSql": null,
+                      "ComputedColumnSql": null,
+                      "IsStored": false,
+                      "Comment": null,
+                      "Collation": null,
+                      "ValueGenerated": null,
+                      "$annotations": null
+                    },
+                    {
+                      "$id": "88",
+                      "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+                      "Table": {
+                        "$ref": "77"
+                      },
+                      "Name": "LockoutEnd",
+                      "IsNullable": true,
+                      "StoreType": "datetimeoffset",
+                      "DefaultValueSql": null,
+                      "ComputedColumnSql": null,
+                      "IsStored": false,
+                      "Comment": null,
+                      "Collation": null,
+                      "ValueGenerated": null,
+                      "$annotations": null
+                    },
+                    {
+                      "$id": "89",
+                      "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+                      "Table": {
+                        "$ref": "77"
+                      },
+                      "Name": "LastLogin",
+                      "IsNullable": true,
+                      "StoreType": "datetimeoffset",
+                      "DefaultValueSql": null,
+                      "ComputedColumnSql": null,
+                      "IsStored": false,
+                      "Comment": null,
+                      "Collation": null,
+                      "ValueGenerated": null,
+                      "$annotations": null
+                    },
+                    {
+                      "$id": "90",
+                      "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+                      "Table": {
+                        "$ref": "77"
+                      },
+                      "Name": "IsDeleted",
+                      "IsNullable": false,
+                      "StoreType": "bit",
+                      "DefaultValueSql": null,
+                      "ComputedColumnSql": null,
+                      "IsStored": false,
+                      "Comment": null,
+                      "Collation": null,
+                      "ValueGenerated": null,
+                      "$annotations": null
+                    },
+                    {
+                      "$id": "91",
+                      "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+                      "Table": {
+                        "$ref": "77"
+                      },
+                      "Name": "Created",
+                      "IsNullable": false,
+                      "StoreType": "datetimeoffset",
+                      "DefaultValueSql": "(sysutcdatetime())",
+                      "ComputedColumnSql": null,
+                      "IsStored": false,
+                      "Comment": null,
+                      "Collation": null,
+                      "ValueGenerated": null,
+                      "$annotations": null
+                    },
+                    {
+                      "$id": "92",
+                      "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+                      "Table": {
+                        "$ref": "77"
+                      },
+                      "Name": "CreatedBy",
+                      "IsNullable": true,
+                      "StoreType": "nvarchar(100)",
+                      "DefaultValueSql": null,
+                      "ComputedColumnSql": null,
+                      "IsStored": false,
+                      "Comment": null,
+                      "Collation": null,
+                      "ValueGenerated": null,
+                      "$annotations": null
+                    },
+                    {
+                      "$id": "93",
+                      "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+                      "Table": {
+                        "$ref": "77"
+                      },
+                      "Name": "Updated",
+                      "IsNullable": false,
+                      "StoreType": "datetimeoffset",
+                      "DefaultValueSql": "(sysutcdatetime())",
+                      "ComputedColumnSql": null,
+                      "IsStored": false,
+                      "Comment": null,
+                      "Collation": null,
+                      "ValueGenerated": null,
+                      "$annotations": null
+                    },
+                    {
+                      "$id": "94",
+                      "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+                      "Table": {
+                        "$ref": "77"
+                      },
+                      "Name": "UpdatedBy",
+                      "IsNullable": true,
+                      "StoreType": "nvarchar(100)",
+                      "DefaultValueSql": null,
+                      "ComputedColumnSql": null,
+                      "IsStored": false,
+                      "Comment": null,
+                      "Collation": null,
+                      "ValueGenerated": null,
+                      "$annotations": null
+                    },
+                    {
+                      "$id": "95",
+                      "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+                      "Table": {
+                        "$ref": "77"
+                      },
+                      "Name": "RowVersion",
+                      "IsNullable": false,
+                      "StoreType": "rowversion",
+                      "DefaultValueSql": null,
+                      "ComputedColumnSql": null,
+                      "IsStored": false,
+                      "Comment": null,
+                      "Collation": null,
+                      "ValueGenerated": 3,
+                      "$annotations": {
+                        "ConcurrencyToken": true
+                      }
+                    }
+                  ]
+                },
+                "UniqueConstraints": {
+                  "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseUniqueConstraint, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+                  "$values": []
+                },
+                "Indexes": {
+                  "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseIndex, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+                  "$values": [
+                    {
+                      "$id": "96",
+                      "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseIndex, Microsoft.EntityFrameworkCore.Relational",
+                      "Table": {
+                        "$ref": "77"
+                      },
+                      "Name": "UX_User_EmailAddress",
+                      "Columns": {
+                        "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+                        "$values": [
+                          {
+                            "$ref": "80"
+                          }
+                        ]
+                      },
+                      "IsUnique": true,
+                      "Filter": null,
+                      "$annotations": null
+                    }
+                  ]
+                },
+                "ForeignKeys": {
+                  "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseForeignKey, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+                  "$values": []
+                },
+                "$annotations": null
+              },
+              "Columns": {
+                "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+                "$values": [
+                  {
+                    "$ref": "65"
+                  }
+                ]
+              },
+              "PrincipalColumns": {
+                "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+                "$values": [
+                  {
+                    "$ref": "79"
+                  }
+                ]
+              },
+              "Name": "FK_Task_User_AssignedId",
+              "OnDelete": 0,
+              "$annotations": null
+            }
+          ]
+        },
+        "$annotations": null
+      },
+      {
+        "$id": "97",
+        "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseTable, Microsoft.EntityFrameworkCore.Relational",
+        "Database": {
+          "$ref": "1"
+        },
+        "Name": "TaskExtended",
+        "Schema": "dbo",
+        "Comment": null,
+        "PrimaryKey": {
+          "$id": "98",
+          "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabasePrimaryKey, Microsoft.EntityFrameworkCore.Relational",
+          "Table": {
+            "$ref": "97"
+          },
+          "Name": "PK_TaskExtended",
+          "Columns": {
+            "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+            "$values": [
+              {
+                "$id": "99",
+                "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+                "Table": {
+                  "$ref": "97"
+                },
+                "Name": "TaskId",
+                "IsNullable": false,
+                "StoreType": "uniqueidentifier",
+                "DefaultValueSql": null,
+                "ComputedColumnSql": null,
+                "IsStored": false,
+                "Comment": null,
+                "Collation": null,
+                "ValueGenerated": null,
+                "$annotations": null
+              }
+            ]
+          },
+          "$annotations": null
+        },
+        "Columns": {
+          "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+          "$values": [
+            {
+              "$ref": "99"
+            },
+            {
+              "$id": "100",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "97"
+              },
+              "Name": "UserAgent",
+              "IsNullable": true,
+              "StoreType": "nvarchar(max)",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "101",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "97"
+              },
+              "Name": "Browser",
+              "IsNullable": true,
+              "StoreType": "nvarchar(256)",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "102",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "97"
+              },
+              "Name": "OperatingSystem",
+              "IsNullable": true,
+              "StoreType": "nvarchar(256)",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "103",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "97"
+              },
+              "Name": "Created",
+              "IsNullable": false,
+              "StoreType": "datetimeoffset",
+              "DefaultValueSql": "(sysutcdatetime())",
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "104",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "97"
+              },
+              "Name": "CreatedBy",
+              "IsNullable": true,
+              "StoreType": "nvarchar(100)",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "105",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "97"
+              },
+              "Name": "Updated",
+              "IsNullable": false,
+              "StoreType": "datetimeoffset",
+              "DefaultValueSql": "(sysutcdatetime())",
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "106",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "97"
+              },
+              "Name": "UpdatedBy",
+              "IsNullable": true,
+              "StoreType": "nvarchar(100)",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "107",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "97"
+              },
+              "Name": "RowVersion",
+              "IsNullable": false,
+              "StoreType": "rowversion",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": 3,
+              "$annotations": {
+                "ConcurrencyToken": true
+              }
+            }
+          ]
+        },
+        "UniqueConstraints": {
+          "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseUniqueConstraint, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+          "$values": []
+        },
+        "Indexes": {
+          "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseIndex, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+          "$values": []
+        },
+        "ForeignKeys": {
+          "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseForeignKey, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+          "$values": [
+            {
+              "$id": "108",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseForeignKey, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "97"
+              },
+              "PrincipalTable": {
+                "$ref": "55"
+              },
+              "Columns": {
+                "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+                "$values": [
+                  {
+                    "$ref": "99"
+                  }
+                ]
+              },
+              "PrincipalColumns": {
+                "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+                "$values": [
+                  {
+                    "$ref": "57"
+                  }
+                ]
+              },
+              "Name": "FK_TaskExtended_Task_TaskId",
+              "OnDelete": 0,
+              "$annotations": null
+            }
+          ]
+        },
+        "$annotations": null
+      },
+      {
+        "$ref": "77"
+      },
+      {
+        "$id": "109",
+        "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseTable, Microsoft.EntityFrameworkCore.Relational",
+        "Database": {
+          "$ref": "1"
+        },
+        "Name": "UserLogin",
+        "Schema": "dbo",
+        "Comment": null,
+        "PrimaryKey": {
+          "$id": "110",
+          "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabasePrimaryKey, Microsoft.EntityFrameworkCore.Relational",
+          "Table": {
+            "$ref": "109"
+          },
+          "Name": "PK_UserLogin",
+          "Columns": {
+            "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+            "$values": [
+              {
+                "$id": "111",
+                "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+                "Table": {
+                  "$ref": "109"
+                },
+                "Name": "Id",
+                "IsNullable": false,
+                "StoreType": "uniqueidentifier",
+                "DefaultValueSql": null,
+                "ComputedColumnSql": null,
+                "IsStored": false,
+                "Comment": null,
+                "Collation": null,
+                "ValueGenerated": null,
+                "$annotations": null
+              }
+            ]
+          },
+          "$annotations": null
+        },
+        "Columns": {
+          "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+          "$values": [
+            {
+              "$ref": "111"
+            },
+            {
+              "$id": "112",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "109"
+              },
+              "Name": "EmailAddress",
+              "IsNullable": false,
+              "StoreType": "nvarchar(256)",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "113",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "109"
+              },
+              "Name": "UserId",
+              "IsNullable": true,
+              "StoreType": "uniqueidentifier",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "114",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "109"
+              },
+              "Name": "UserAgent",
+              "IsNullable": true,
+              "StoreType": "nvarchar(max)",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "115",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "109"
+              },
+              "Name": "Browser",
+              "IsNullable": true,
+              "StoreType": "nvarchar(256)",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "116",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "109"
+              },
+              "Name": "OperatingSystem",
+              "IsNullable": true,
+              "StoreType": "nvarchar(256)",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "117",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "109"
+              },
+              "Name": "DeviceFamily",
+              "IsNullable": true,
+              "StoreType": "nvarchar(256)",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "118",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "109"
+              },
+              "Name": "DeviceBrand",
+              "IsNullable": true,
+              "StoreType": "nvarchar(256)",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "119",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "109"
+              },
+              "Name": "DeviceModel",
+              "IsNullable": true,
+              "StoreType": "nvarchar(256)",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "120",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "109"
+              },
+              "Name": "IpAddress",
+              "IsNullable": true,
+              "StoreType": "nvarchar(50)",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "121",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "109"
+              },
+              "Name": "IsSuccessful",
+              "IsNullable": false,
+              "StoreType": "bit",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "122",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "109"
+              },
+              "Name": "FailureMessage",
+              "IsNullable": true,
+              "StoreType": "nvarchar(256)",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "123",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "109"
+              },
+              "Name": "Created",
+              "IsNullable": false,
+              "StoreType": "datetimeoffset",
+              "DefaultValueSql": "(sysutcdatetime())",
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "124",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "109"
+              },
+              "Name": "CreatedBy",
+              "IsNullable": true,
+              "StoreType": "nvarchar(100)",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "125",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "109"
+              },
+              "Name": "Updated",
+              "IsNullable": false,
+              "StoreType": "datetimeoffset",
+              "DefaultValueSql": "(sysutcdatetime())",
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "126",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "109"
+              },
+              "Name": "UpdatedBy",
+              "IsNullable": true,
+              "StoreType": "nvarchar(100)",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": null,
+              "$annotations": null
+            },
+            {
+              "$id": "127",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "109"
+              },
+              "Name": "RowVersion",
+              "IsNullable": false,
+              "StoreType": "rowversion",
+              "DefaultValueSql": null,
+              "ComputedColumnSql": null,
+              "IsStored": false,
+              "Comment": null,
+              "Collation": null,
+              "ValueGenerated": 3,
+              "$annotations": {
+                "ConcurrencyToken": true
+              }
+            }
+          ]
+        },
+        "UniqueConstraints": {
+          "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseUniqueConstraint, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+          "$values": []
+        },
+        "Indexes": {
+          "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseIndex, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+          "$values": [
+            {
+              "$id": "128",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseIndex, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "109"
+              },
+              "Name": "IX_UserLogin_EmailAddress",
+              "Columns": {
+                "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+                "$values": [
+                  {
+                    "$ref": "112"
+                  }
+                ]
+              },
+              "IsUnique": false,
+              "Filter": null,
+              "$annotations": null
+            },
+            {
+              "$id": "129",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseIndex, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "109"
+              },
+              "Name": "IX_UserLogin_UserId",
+              "Columns": {
+                "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+                "$values": [
+                  {
+                    "$ref": "113"
+                  }
+                ]
+              },
+              "IsUnique": false,
+              "Filter": null,
+              "$annotations": null
+            }
+          ]
+        },
+        "ForeignKeys": {
+          "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseForeignKey, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+          "$values": [
+            {
+              "$id": "130",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseForeignKey, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "109"
+              },
+              "PrincipalTable": {
+                "$ref": "77"
+              },
+              "Columns": {
+                "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+                "$values": [
+                  {
+                    "$ref": "113"
+                  }
+                ]
+              },
+              "PrincipalColumns": {
+                "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+                "$values": [
+                  {
+                    "$ref": "79"
+                  }
+                ]
+              },
+              "Name": "FK_UserLogin_User_UserId",
+              "OnDelete": 0,
+              "$annotations": null
+            }
+          ]
+        },
+        "$annotations": null
+      },
+      {
+        "$id": "131",
+        "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseTable, Microsoft.EntityFrameworkCore.Relational",
+        "Database": {
+          "$ref": "1"
+        },
+        "Name": "UserRole",
+        "Schema": "dbo",
+        "Comment": null,
+        "PrimaryKey": {
+          "$id": "132",
+          "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabasePrimaryKey, Microsoft.EntityFrameworkCore.Relational",
+          "Table": {
+            "$ref": "131"
+          },
+          "Name": "PK_UserRole",
+          "Columns": {
+            "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+            "$values": [
+              {
+                "$id": "133",
+                "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+                "Table": {
+                  "$ref": "131"
+                },
+                "Name": "UserId",
+                "IsNullable": false,
+                "StoreType": "uniqueidentifier",
+                "DefaultValueSql": null,
+                "ComputedColumnSql": null,
+                "IsStored": false,
+                "Comment": null,
+                "Collation": null,
+                "ValueGenerated": null,
+                "$annotations": null
+              },
+              {
+                "$id": "134",
+                "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational",
+                "Table": {
+                  "$ref": "131"
+                },
+                "Name": "RoleId",
+                "IsNullable": false,
+                "StoreType": "uniqueidentifier",
+                "DefaultValueSql": null,
+                "ComputedColumnSql": null,
+                "IsStored": false,
+                "Comment": null,
+                "Collation": null,
+                "ValueGenerated": null,
+                "$annotations": null
+              }
+            ]
+          },
+          "$annotations": null
+        },
+        "Columns": {
+          "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+          "$values": [
+            {
+              "$ref": "133"
+            },
+            {
+              "$ref": "134"
+            }
+          ]
+        },
+        "UniqueConstraints": {
+          "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseUniqueConstraint, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+          "$values": []
+        },
+        "Indexes": {
+          "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseIndex, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+          "$values": []
+        },
+        "ForeignKeys": {
+          "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseForeignKey, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+          "$values": [
+            {
+              "$id": "135",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseForeignKey, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "131"
+              },
+              "PrincipalTable": {
+                "$ref": "27"
+              },
+              "Columns": {
+                "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+                "$values": [
+                  {
+                    "$ref": "134"
+                  }
+                ]
+              },
+              "PrincipalColumns": {
+                "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+                "$values": [
+                  {
+                    "$ref": "29"
+                  }
+                ]
+              },
+              "Name": "FK_UserRole_Role_RoleId",
+              "OnDelete": 0,
+              "$annotations": null
+            },
+            {
+              "$id": "136",
+              "$type": "Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseForeignKey, Microsoft.EntityFrameworkCore.Relational",
+              "Table": {
+                "$ref": "131"
+              },
+              "PrincipalTable": {
+                "$ref": "77"
+              },
+              "Columns": {
+                "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+                "$values": [
+                  {
+                    "$ref": "133"
+                  }
+                ]
+              },
+              "PrincipalColumns": {
+                "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseColumn, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+                "$values": [
+                  {
+                    "$ref": "79"
+                  }
+                ]
+              },
+              "Name": "FK_UserRole_User_UserId",
+              "OnDelete": 0,
+              "$annotations": null
+            }
+          ]
+        },
+        "$annotations": null
+      }
+    ]
+  },
+  "Sequences": {
+    "$type": "System.Collections.Generic.List`1[[Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseSequence, Microsoft.EntityFrameworkCore.Relational]], System.Private.CoreLib",
+    "$values": []
+  },
+  "$annotations": {
+    "EFG:Args": {
+      "$id": "137",
+      "$type": "System.Collections.Generic.List`1[[System.String, System.Private.CoreLib]], System.Private.CoreLib",
+      "$values": [
+        "C:\\REDACTED\\EntityFrameworkCore.Generator\\src\\EntityFrameworkCore.Generator\\bin\\Debug\\netcoreapp3.1\\EntityFrameworkCore.Generator.dll",
+        "refresh",
+        "-f",
+        ".\\generation.efg.yml"
+      ]
+    },
+    "EFG:CLI": "C:\\REDACTED\\EntityFrameworkCore.Generator\\src\\EntityFrameworkCore.Generator\\bin\\Debug\\netcoreapp3.1\\EntityFrameworkCore.Generator.dll refresh -f .\\generation.efg.yml",
+    "EFG:CLRVersion": "3.1.8",
+    "EFG:CreatedTime": "2020-12-14T21:21:18.3449412-05:00",
+    "EFG:OS": {
+      "$id": "138",
+      "$type": "System.OperatingSystem, System.Private.CoreLib",
+      "Platform": 2,
+      "ServicePack": "",
+      "Version": "6.2.9200.0",
+      "VersionString": "Microsoft Windows NT 6.2.9200.0"
+    }
+  }
+}

--- a/sample/Tracker/Tracker.Core-CS9Gen/generation.efg.yml
+++ b/sample/Tracker/Tracker.Core-CS9Gen/generation.efg.yml
@@ -1,10 +1,10 @@
 project:
-  #namespace: '{Database.Name}.Core'
+  namespace: '{Database.Name}.Core'
   namespace: 'Tracker.Core'
   directory: '{Options.Directory}\_efg\{Options.FileNameWithoutExtension}\'
 database:
   provider: SqlServer
-  connectionString: Data Source=(local)\SQLEXPRESS;Initial Catalog=EFG_TrackerTest;Integrated Security=True
+  connectionString: Data Source=(local)\SQLEXPRESS;Initial Catalog=Tracker;Integrated Security=True
   exclude:
     - exact: 'dbo.SchemaVersions'
 data:

--- a/sample/Tracker/Tracker.Core-CS9Gen/generation.efg.yml
+++ b/sample/Tracker/Tracker.Core-CS9Gen/generation.efg.yml
@@ -1,0 +1,81 @@
+project:
+  #namespace: '{Database.Name}.Core'
+  namespace: 'Tracker.Core'
+  directory: '{Options.Directory}\_efg\{Options.FileNameWithoutExtension}\'
+database:
+  provider: SqlServer
+  connectionString: Data Source=(local)\SQLEXPRESS;Initial Catalog=EFG_TrackerTest;Integrated Security=True
+  exclude:
+    - exact: 'dbo.SchemaVersions'
+data:
+  context:
+    name: '{Database.Name}Context'
+    baseClass: DbContext
+    namespace: '{Project.Namespace}.Data'
+    directory: '{Project.Directory}\Data'
+    document: true
+  entity:
+    namespace: '{Project.Namespace}.Data.Entities'
+    directory: '{Project.Directory}\Data\Entities'
+    document: true
+  mapping:
+    namespace: '{Project.Namespace}.Data.Mapping'
+    directory: '{Project.Directory}\Data\Mapping'
+    document: true
+  query:
+    generate: true
+    indexPrefix: By
+    uniquePrefix: GetBy
+    namespace: '{Project.Namespace}.Data.Queries'
+    directory: '{Project.Directory}\Data\Queries'
+    document: true
+model:
+  shared:
+    namespace: '{Project.Namespace}.Domain.Models'
+    directory: '{Project.Directory}\Domain\{Entity.Name}\Models'
+    exclude:
+      properties:
+        - '\.Id$'
+        - '\.Created$'
+        - '\.CreatedBy$'
+        - '\.Updated$'
+        - '\.UpdatedBy$'
+        - '\.RowVersion$'
+        - 'User\.PasswordHash$'
+        - 'User\.ResetHash$'
+        - 'User\.InviteHash$'
+  read:
+    generate: true
+    name: '{Entity.Name}ReadModel'
+    baseClass: EntityReadModel
+    document: true
+  create:
+    generate: true
+    name: '{Entity.Name}CreateModel'
+    baseClass: EntityCreateModel
+    document: true
+    exclude:
+      entities:
+        - 'UserLogin'
+  update:
+    generate: true
+    name: '{Entity.Name}UpdateModel'
+    baseClass: EntityUpdateModel
+    document: true
+    exclude:
+      entities:
+        - 'UserLogin'
+  mapper:
+    generate: true
+    name: '{Entity.Name}Profile'
+    baseClass: Profile
+    namespace: '{Project.Namespace}.Domain.Mapping'
+    directory: '{Project.Directory}\Domain\{Entity.Name}\Mapping'
+    document: true
+  validator:
+    generate: true
+    name: '{Model.Name}Validator'
+    baseClass: 'AbstractValidator<{Model.Name}>'
+    namespace: '{Project.Namespace}.Domain.Validation'
+    directory: '{Project.Directory}\Domain\{Entity.Name}\Validation'
+    document: true

--- a/sample/Tracker/Tracker.Core-CS9Gen/generation.efg.yml
+++ b/sample/Tracker/Tracker.Core-CS9Gen/generation.efg.yml
@@ -10,7 +10,8 @@ database:
 data:
   context:
     name: '{Database.Name}Context'
-    baseClass: DbContext
+    #baseClass: DbContext
+    baseClass: TrackerContextBase
     namespace: '{Project.Namespace}.Data'
     directory: '{Project.Directory}\Data'
     document: true

--- a/sample/Tracker/Tracker.Web/Tracker.Web.csproj
+++ b/sample/Tracker/Tracker.Web/Tracker.Web.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Tracker.Core\Tracker.Core.csproj" />
+    <ProjectReference Include="..\Tracker.Core-CS9Gen\Tracker.Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/sample/Tracker/Tracker.sln
+++ b/sample/Tracker/Tracker.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tracker.Core", "Tracker.Cor
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tracker.Web", "Tracker.Web\Tracker.Web.csproj", "{3AFA31A4-FFA3-4651-867D-BF674CF26A17}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tracker.Core", "Tracker.Core-CS9Gen\Tracker.Core.csproj", "{C71AB5EB-7625-42CE-B1ED-A27EB74D3779}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -41,6 +43,18 @@ Global
 		{3AFA31A4-FFA3-4651-867D-BF674CF26A17}.Release|x64.Build.0 = Release|Any CPU
 		{3AFA31A4-FFA3-4651-867D-BF674CF26A17}.Release|x86.ActiveCfg = Release|Any CPU
 		{3AFA31A4-FFA3-4651-867D-BF674CF26A17}.Release|x86.Build.0 = Release|Any CPU
+		{C71AB5EB-7625-42CE-B1ED-A27EB74D3779}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C71AB5EB-7625-42CE-B1ED-A27EB74D3779}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C71AB5EB-7625-42CE-B1ED-A27EB74D3779}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C71AB5EB-7625-42CE-B1ED-A27EB74D3779}.Debug|x64.Build.0 = Debug|Any CPU
+		{C71AB5EB-7625-42CE-B1ED-A27EB74D3779}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C71AB5EB-7625-42CE-B1ED-A27EB74D3779}.Debug|x86.Build.0 = Debug|Any CPU
+		{C71AB5EB-7625-42CE-B1ED-A27EB74D3779}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C71AB5EB-7625-42CE-B1ED-A27EB74D3779}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C71AB5EB-7625-42CE-B1ED-A27EB74D3779}.Release|x64.ActiveCfg = Release|Any CPU
+		{C71AB5EB-7625-42CE-B1ED-A27EB74D3779}.Release|x64.Build.0 = Release|Any CPU
+		{C71AB5EB-7625-42CE-B1ED-A27EB74D3779}.Release|x86.ActiveCfg = Release|Any CPU
+		{C71AB5EB-7625-42CE-B1ED-A27EB74D3779}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/EntityFrameworkCore.Generator.CS9Generator/EFGSourceGenerator.cs
+++ b/src/EntityFrameworkCore.Generator.CS9Generator/EFGSourceGenerator.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.IO;
+using Microsoft.CodeAnalysis;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EntityFrameworkCore.Generator.CS9Generator
+{
+    [Generator]
+    public class EFGSourceGenerator : ISourceGenerator
+    {
+        private IServiceProvider _services;
+
+        public void Initialize(GeneratorInitializationContext context)
+        {
+            _services = new ServiceCollection()
+                .AddLogging()
+                .AddTransient<IGeneratorOptionsSerializer, GeneratorOptionsSerializer>()
+                .AddTransient<ICodeGenerator, CodeGenerator>()
+                .AddTransient<IModelCacheBuilder, ModelCacheBuilder>()
+                .BuildServiceProvider();
+        }
+        
+        public void Execute(GeneratorExecutionContext context)
+        {
+            IGeneratorOptionsSerializer gos = _services.GetRequiredService<IGeneratorOptionsSerializer>();
+            ICodeGenerator cg = _services.GetRequiredService<ICodeGenerator>();
+
+            foreach (var addTxt in context.AdditionalFiles)
+            {
+                if (addTxt.Path.EndsWith(".efg.yml") || addTxt.Path.EndsWith(".efg.yaml"))
+                {
+                    var fullPath = addTxt.Path;
+                    var directory = Path.GetDirectoryName(fullPath);
+                    var fileName = Path.GetFileName(fullPath);
+                    var fileNameWOext = Path.GetFileNameWithoutExtension(fullPath);
+                    if (fileNameWOext.EndsWith(".efg", StringComparison.OrdinalIgnoreCase))
+                        fileNameWOext = Path.GetFileNameWithoutExtension(fileNameWOext);
+
+                    // throw new Exception("GENERATED: " + fileNameWOext);
+
+                    context.AddSource($"EFG_{fileNameWOext}", $@"
+namespace EFG.Generated
+{{
+    class {fileNameWOext}
+    {{
+        public const string Name = ""{fileNameWOext}"";
+    }}
+}}");
+
+                    var options = gos.Load(directory, fileName);
+                    cg.Generate(options, fromCache: true, updateFromSource: false);
+                }
+            }
+        }
+    }
+}

--- a/src/EntityFrameworkCore.Generator.CS9Generator/EFGSourceGenerator.cs
+++ b/src/EntityFrameworkCore.Generator.CS9Generator/EFGSourceGenerator.cs
@@ -48,6 +48,16 @@ namespace EFG.Generated
 }}");
 
                     var options = gos.Load(directory, fileName);
+                    var root = Path.GetFullPath(options.Project.Directory);
+
+                    options.CodeWriter = (fullPath, content) =>
+                    {
+                        var relPath = Path.GetFullPath(fullPath).Replace(root, "");
+                        var nameHint = relPath.Replace("\\", "__").Replace("/", "__");
+                        //File.WriteAllText(fullPath, $"// This is a test [{fullPath}]\r\n// Rel: [{rel}]\r\n");
+                        context.AddSource(nameHint, content);
+                    };
+
                     cg.Generate(options, fromCache: true, updateFromSource: false);
                 }
             }

--- a/src/EntityFrameworkCore.Generator.CS9Generator/EntityFrameworkCore.Generator.CS9Generator.csproj
+++ b/src/EntityFrameworkCore.Generator.CS9Generator/EntityFrameworkCore.Generator.CS9Generator.csproj
@@ -1,0 +1,82 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+<PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <LangVersion>preview</LangVersion>
+    <!-- <GeneratePackageOnBuild>true</GeneratePackageOnBuild> -->
+</PropertyGroup>
+
+<ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" PrivateAssets="all" />
+</ItemGroup>
+
+<ItemGroup>
+    <!-- Generator dependencies -->
+    <GeneratorPackageReference TF="netstandard2.1" Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
+    <GeneratorPackageReference TF="netstandard2.0" Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
+    <GeneratorPackageReference TF="netstandard2.1" Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <GeneratorPackageReference TF="netstandard2.0" Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
+    <GeneratorPackageReference TF="netstandard2.0" Include="Microsoft.Extensions.Options" Version="5.0.0" />
+    <GeneratorPackageReference TF="netstandard2.0" Include="Microsoft.Extensions.Primitives" Version="5.0.0" />
+    <GeneratorPackageReference TF="netstandard2.0" Include="Newtonsoft.Json" Version="12.0.3" />
+    <GeneratorPackageReference TF="netstandard2.1" Include="Microsoft.EntityFrameworkCore" Version="5.0.0.0" />
+    <GeneratorPackageReference TF="netstandard2.1" Include="Microsoft.EntityFrameworkCore.Abstractions" Version="5.0.0.0" />
+    <GeneratorPackageReference TF="netstandard2.1" Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.0.0" />
+    <GeneratorPackageReference TF="netstandard2.1" Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.0.0" />
+    <GeneratorPackageReference TF="netstandard2.1" Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.0.0" />
+    <GeneratorPackageReference TF="netstandard2.1" Include="YamlDotNet" Version="9.1.0" />
+    <GeneratorPackageReference TF="netstandard2.0" Include="Humanizer.Core" Version="2.8.26" />
+    
+    <!-- Convert all Generatoer Package References to normal pkg refs -->
+    <PackageReference Include="@(GeneratorPackageReference)" PrivateAssets="all" GeneratePathProperty="true" Version="%(version)" />
+
+</ItemGroup>
+
+<ItemGroup>
+    <!-- Local project dependency -->
+    <ProjectReference Include="..\EntityFrameworkCore.Generator.Core\EntityFrameworkCore.Generator.Core.csproj" />
+</ItemGroup>
+
+<PropertyGroup>
+    <GetTargetPathDependsOn>$(GetTargetPathDependsOn);GetDependencyTargetPaths</GetTargetPathDependsOn>
+</PropertyGroup>
+
+<Target Name="GetDependencyTargetPaths">
+    <ItemGroup>
+    <GenPkgRefUnders Include="@(GeneratorPackageReference -&gt; Replace('.', '_'))">
+        <TF>%(TF)</TF>
+    </GenPkgRefUnders>
+    <GenPkgRefLookup Include="@(GenPkgRefUnders -> 'Pkg%(filename)')">
+        <TF>%(TF)</TF>
+    </GenPkgRefLookup>
+    <GenPkgRefNuPath Include="@(GenPkgRefLookup)">
+        <Path>$(%(GenPkgRefLookup.filename))\lib\%(TF)\*.dll</Path>
+    </GenPkgRefNuPath>
+    </ItemGroup>
+    <Message Importance="High" Text="Packaging Up: @(GenPkgRefNuPath -> '%(Path)')" />
+    <CreateItem Include="@(GenPkgRefNuPath -> '%(Path)')">
+        <Output TaskParameter="Include" ItemName="GenPkgRefFullPath" />
+    </CreateItem>
+
+    <!-- DEBUG -->
+    <PropertyGroup>
+        <AllGenPkgRefFullPaths>@(GenPkgRefFullPath)</AllGenPkgRefFullPaths>
+    </PropertyGroup>
+    <Message Importance="High" Text="***************************************************************************" />
+    <Message Importance="High" Text="Resolved Gen Pkg Ref Paths: %0A$(AllGenPkgRefFullPaths.Replace(';', '%0A'))" />
+    <Message Importance="High" Text="***************************************************************************" />
+
+    <ItemGroup>
+        <!-- Enumerate the full path of all dependencies to be packaged up -->
+        <TargetPathWithTargetPlatformMoniker IncludeRuntimeDependency="false" Include="@(GenPkgRefFullPath)" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <!-- Include the local project dependency -->
+        <TargetPathWithTargetPlatformMoniker IncludeRuntimeDependency="false" Include="$(MSBuildProjectDirectory)\..\EntityFrameworkCore.Generator.Core\bin\$(Configuration)\netstandard2.1\EntityFrameworkCore.Generator.Core.dll" />
+    </ItemGroup>
+</Target>
+
+</Project>

--- a/src/EntityFrameworkCore.Generator.Core/CodeGenerator.cs
+++ b/src/EntityFrameworkCore.Generator.Core/CodeGenerator.cs
@@ -36,26 +36,7 @@ namespace EntityFrameworkCore.Generator
 
         public GeneratorOptions Options { get; set; }
 
-        public bool Generate(GeneratorOptions options)
-        {
-            Options = options ?? throw new ArgumentNullException(nameof(options));
-
-            var databaseProviders = GetDatabaseProviders();
-            var databaseModel = GetDatabaseModel(databaseProviders.factory);
-
-            if (databaseModel == null)
-                throw new InvalidOperationException("Failed to create database model");
-
-            _logger.LogInformation("Loaded database model for: {databaseName}", databaseModel.DatabaseName);
-
-            var context = _modelGenerator.Generate(Options, databaseModel, databaseProviders.mapping);
-
-            _synchronizer.UpdateFromSource(context, options);
-
-            GenerateFiles(context);
-
-            return true;
-        }
+        public bool Generate(GeneratorOptions options) => Generate(options, false, true);
 
         public bool Generate(GeneratorOptions options, bool fromCache, bool updateFromSource)
         {

--- a/src/EntityFrameworkCore.Generator.Core/EntityFrameworkCore.Generator.Core.csproj
+++ b/src/EntityFrameworkCore.Generator.Core/EntityFrameworkCore.Generator.Core.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.0" />
     <PackageReference Include="YamlDotNet" Version="9.1.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3"/>
   </ItemGroup>
 
 </Project>

--- a/src/EntityFrameworkCore.Generator.Core/EntityFrameworkCore.Generator.Core.csproj
+++ b/src/EntityFrameworkCore.Generator.Core/EntityFrameworkCore.Generator.Core.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.8.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="5.0.0" />
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="3.2.4" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="5.0.0-alpha.2" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.0" />

--- a/src/EntityFrameworkCore.Generator.Core/GeneratorOptionsSerializer.cs
+++ b/src/EntityFrameworkCore.Generator.Core/GeneratorOptionsSerializer.cs
@@ -55,6 +55,7 @@ namespace EntityFrameworkCore.Generator
             using (var streamReader = File.OpenText(path))
                 generatorOptions = deserializer.Deserialize<GeneratorOptions>(streamReader);
 
+            generatorOptions.Options.SetFullPath(path);
             generatorOptions.Variables.ShouldEvaluate = true;
             return generatorOptions;
         }

--- a/src/EntityFrameworkCore.Generator.Core/ICodeGenerator.cs
+++ b/src/EntityFrameworkCore.Generator.Core/ICodeGenerator.cs
@@ -6,5 +6,7 @@ namespace EntityFrameworkCore.Generator
     public interface ICodeGenerator
     {
         bool Generate(GeneratorOptions options);
+
+        bool Generate(GeneratorOptions options, bool fromCache, bool updateFromSource);
     }
 }

--- a/src/EntityFrameworkCore.Generator.Core/IModelCacheBuilder.cs
+++ b/src/EntityFrameworkCore.Generator.Core/IModelCacheBuilder.cs
@@ -1,0 +1,11 @@
+using EntityFrameworkCore.Generator.Options;
+using Microsoft.EntityFrameworkCore.Scaffolding.Metadata;
+
+namespace EntityFrameworkCore.Generator
+{
+    public interface IModelCacheBuilder
+    {
+         bool Refresh(GeneratorOptions options);
+         DatabaseModel LoadFromCache(GeneratorOptions options);
+    }
+}

--- a/src/EntityFrameworkCore.Generator.Core/ModelCache/AnnotationsContractResolver.cs
+++ b/src/EntityFrameworkCore.Generator.Core/ModelCache/AnnotationsContractResolver.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace EntityFrameworkCore.Generator.ModelCache
+{
+    public class AnnotationsContractResolver : DefaultContractResolver
+    {
+        public static readonly AnnotationsContractResolver Instance =
+            new AnnotationsContractResolver();
+
+        private static readonly Dictionary<Type, JsonProperty> _annotationPropertyByDeclaryingType =
+            new Dictionary<Type, JsonProperty>();
+
+        public static IEnumerable<Type> DeclaringTypes => _annotationPropertyByDeclaryingType.Keys;
+
+        public static JsonProperty GetAnnotationProperty(Type declaringType)
+        {
+            if (!_annotationPropertyByDeclaryingType.TryGetValue(declaringType, out var property))
+            {
+                property = new JsonProperty
+                {
+                    DeclaringType = declaringType,
+                    PropertyType = typeof(IEnumerable<Annotation>),
+                    PropertyName = "$annotations",
+                    Readable = true,
+                    Writable = true,
+                    ValueProvider = AnnotationsValueProvider.Instance,
+                };
+                _annotationPropertyByDeclaryingType.Add(declaringType, property);
+            }
+            return property;
+        }
+
+        protected override IList<JsonProperty> CreateProperties(Type type, MemberSerialization memberSerialization)
+        {
+            var props = base.CreateProperties(type, memberSerialization);
+
+            if (typeof(Annotatable).IsAssignableFrom(type))
+            {
+                props.Add(GetAnnotationProperty(type));
+            }
+
+            return props;
+        }
+    }
+}

--- a/src/EntityFrameworkCore.Generator.Core/ModelCache/AnnotationsJsonConverter.cs
+++ b/src/EntityFrameworkCore.Generator.Core/ModelCache/AnnotationsJsonConverter.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Newtonsoft.Json;
+
+namespace EntityFrameworkCore.Generator.ModelCache
+{
+    public class AnnotationsJsonConverter : JsonConverter<IEnumerable<Annotation>>
+    {
+        public static readonly AnnotationsJsonConverter Instance = new AnnotationsJsonConverter();
+
+        public override void WriteJson(JsonWriter writer, [AllowNull] IEnumerable<Annotation> value, JsonSerializer serializer)
+        {
+            writer.WriteStartObject();
+            foreach (var a in value)
+            {
+                writer.WritePropertyName(a.Name);
+                serializer.Serialize(writer, a.Value);
+            }
+            writer.WriteEndObject();
+        }
+
+        public override IEnumerable<Annotation> ReadJson(JsonReader reader, Type objectType, [AllowNull] IEnumerable<Annotation> existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null)
+            {
+                return null;
+            }
+            else if (reader.TokenType == JsonToken.StartObject)
+            {
+                reader.Read();
+                var list = new List<Annotation>();
+                while (reader.TokenType != JsonToken.EndObject)
+                {
+                    if (reader.TokenType != JsonToken.PropertyName)
+                        throw new JsonSerializationException("Unexpected token type found where property name expected in Annotation object:" + reader.TokenType);
+                    var name = (string)reader.Value;
+                    //Console.WriteLine("Reading ann: " + name);
+                    reader.Read();
+                    var value = serializer.Deserialize(reader);
+                    reader.Read();
+                    list.Add(new Annotation(name, value));
+                }
+                return list;
+            }
+            else
+            {
+                throw new JsonSerializationException("Unexpected token type found at start of Annotation: " + reader.TokenType);
+            }
+        }
+    }
+}

--- a/src/EntityFrameworkCore.Generator.Core/ModelCache/AnnotationsValueProvider.cs
+++ b/src/EntityFrameworkCore.Generator.Core/ModelCache/AnnotationsValueProvider.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Newtonsoft.Json.Serialization;
+
+namespace EntityFrameworkCore.Generator.ModelCache
+{
+    public class AnnotationsValueProvider : IValueProvider
+    {
+        public static readonly AnnotationsValueProvider Instance = new AnnotationsValueProvider();
+
+        public object GetValue(object target)
+        {
+            var annotatable = (Annotatable)target;
+            var annotations = annotatable.GetAnnotations();
+            if (annotations == null || annotations.Count() == 0)
+            {
+                return null;
+            }
+            return annotations; //.Select(a => KeyValuePair.Create(a.Name, a.Value)).ToList();
+        }
+
+        public void SetValue(object target, object value)
+        {
+            if (target is Annotatable annotatable
+                && value is IEnumerable<Annotation> annotations)
+            {
+                foreach (var a in annotations)
+                {
+                    annotatable.AddAnnotation(a.Name, a.Value);
+                }
+            }
+        }
+    }
+}

--- a/src/EntityFrameworkCore.Generator.Core/ModelCache/KeyValueTuplesJsonConverter.cs
+++ b/src/EntityFrameworkCore.Generator.Core/ModelCache/KeyValueTuplesJsonConverter.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Newtonsoft.Json;
+
+namespace EntityFrameworkCore.Generator.ModelCache
+{
+    public class KeyValueTuplesJsonConverter : JsonConverter<IEnumerable<(string, object)>>
+    {
+        public static readonly KeyValueTuplesJsonConverter Instance =
+            new KeyValueTuplesJsonConverter();
+
+        public override void WriteJson(JsonWriter writer, [AllowNull] IEnumerable<(string, object)> value, JsonSerializer serializer)
+        {
+            writer.WriteStartObject();
+            foreach (var kv in value.OrderBy(kv => kv.Item1))
+            {
+                writer.WritePropertyName(kv.Item1);
+                serializer.Serialize(writer, kv.Item2);
+            }
+            writer.WriteEndObject();
+        }
+
+        public override IEnumerable<(string, object)> ReadJson(JsonReader reader, Type objectType, [AllowNull] IEnumerable<(string, object)> existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null)
+            {
+                return null;
+            }
+            else if (reader.TokenType == JsonToken.StartObject)
+            {
+                reader.Read();
+                var list = new List<(string, object)>();
+                while (reader.TokenType != JsonToken.EndObject)
+                {
+                    if (reader.TokenType != JsonToken.PropertyName)
+                        throw new JsonSerializationException("Unexpected token type found where property name expected in KeyValueTuples object:" + reader.TokenType);
+                    var name = (string)reader.Value;
+                    reader.Read();
+                    var value = serializer.Deserialize(reader);
+                    reader.Read();
+                    list.Add((name, value));
+                }
+                return list;
+            }
+            else
+            {
+                throw new JsonSerializationException("Unexpected token type found at start of KeyValueTuples: " + reader.TokenType);
+            }
+        }
+    }
+}

--- a/src/EntityFrameworkCore.Generator.Core/ModelCacheBuilder.cs
+++ b/src/EntityFrameworkCore.Generator.Core/ModelCacheBuilder.cs
@@ -1,0 +1,166 @@
+using System;
+using System.IO;
+using System.Linq;
+using EntityFrameworkCore.Generator.Extensions;
+using EntityFrameworkCore.Generator.ModelCache;
+using EntityFrameworkCore.Generator.Options;
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.EntityFrameworkCore.Scaffolding;
+using Microsoft.EntityFrameworkCore.Scaffolding.Metadata;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace EntityFrameworkCore.Generator.Core
+{
+    public class ModelCacheBuilder : IModelCacheBuilder
+    {
+        public const string DefaultModelCacheFileName = "dbmodel.cache.json";
+
+        private readonly ILoggerFactory _loggerFactory;
+        private readonly ILogger _logger;
+
+        public ModelCacheBuilder(ILoggerFactory loggerFactory)
+        {
+            _loggerFactory = loggerFactory;
+            _logger = loggerFactory.CreateLogger<ModelCacheBuilder>();
+        }
+
+        public bool Refresh(GeneratorOptions options)
+        {
+            if (options == null)
+                throw new ArgumentNullException(nameof(options));
+
+            return RefreshFromScratch(options);
+        }
+
+        public DatabaseModel LoadFromCache(GeneratorOptions options)
+        {
+            if (options == null)
+                throw new ArgumentNullException(nameof(options));
+
+            var dir = Path.GetFullPath(options.Project.Directory);
+            var ser = Path.Combine(dir, DefaultModelCacheFileName);
+
+            _logger.LogInformation("Computed DB model cache file: {modelCacheFile}", ser);
+
+            if (!File.Exists(ser))
+            {
+                throw new Exception("No cached database model found; did you generate it?");
+            }
+
+            var dbModel = Deserialize(File.ReadAllText(ser));
+
+            return dbModel;
+        }
+
+        private bool RefreshFromScratch(GeneratorOptions options)
+        {
+            var services = new ServiceCollection();
+
+            _logger.LogInformation("Adding EF Design-time Services");
+            services.AddEntityFrameworkDesignTimeServices();
+
+            IDesignTimeServices dts;
+            // This part is DB-specific
+            var provider = options.Database.Provider;
+            dts = provider switch {
+                DatabaseProviders.SqlServer =>
+                    new Microsoft.EntityFrameworkCore.SqlServer.Design.Internal.SqlServerDesignTimeServices(),
+                DatabaseProviders.PostgreSQL =>
+                    new Npgsql.EntityFrameworkCore.PostgreSQL.Design.Internal.NpgsqlDesignTimeServices(),
+                DatabaseProviders.MySQL =>
+                    new Pomelo.EntityFrameworkCore.MySql.Design.Internal.MySqlDesignTimeServices(),
+                DatabaseProviders.Sqlite =>
+                    new Microsoft.EntityFrameworkCore.Sqlite.Design.Internal.SqliteDesignTimeServices(),
+
+                // TODO: add support for user-provided custom implementation class for IDesignTimeServices
+
+                _ => throw new NotSupportedException($"The specified provider '{provider}' is not supported."),
+            };
+
+            _logger.LogInformation("Configuring EF Design-time Services for provider: {provider}", provider);
+            dts.ConfigureDesignTimeServices(services);
+
+            var serviceProviders = services.BuildServiceProvider();
+            var dbmFactory = serviceProviders.GetRequiredService<IDatabaseModelFactory>();
+            var tmSource = serviceProviders.GetRequiredService<IRelationalTypeMappingSource>();
+
+            var connectionString = ResolveConnectionString(options.Database);
+            var dbmFactoryOptions = new DatabaseModelFactoryOptions(
+                tables: options.Database.Tables, // null to include all
+                schemas: options.Database.Schemas // null to include all
+            );
+
+            // Extract the Database Model
+            _logger.LogInformation("Building DB Model");
+            var dbModel = dbmFactory.Create(connectionString, dbmFactoryOptions);
+
+            // Add a few of our own annotations for additional context
+            dbModel.AddAnnotation("EFG:CreatedTime",
+                DateTime.Now);
+            dbModel.AddAnnotation("EFG:CLRVersion",
+                System.Environment.Version);
+            dbModel.AddAnnotation("EFG:OS",
+                System.Environment.OSVersion);
+            dbModel.AddAnnotation("EFG:CLI",
+                System.Environment.CommandLine);
+            dbModel.AddAnnotation("EFG:Args",
+                System.Environment.GetCommandLineArgs().ToList());
+
+            var dir = Path.GetFullPath(options.Project.Directory);
+            var ser = Path.Combine(dir, DefaultModelCacheFileName);
+            _logger.LogInformation("Computed DB model cache file: {modelCacheFile}", ser);
+
+            Directory.CreateDirectory(dir);
+            File.WriteAllText(ser, Serialize(dbModel));
+            _logger.LogInformation("Serialized DB Model to cache file");
+
+            return true;
+        }
+
+        public static string ResolveConnectionString(DatabaseOptions database)
+        {
+            if (database.ConnectionString.HasValue())
+                return database.ConnectionString;
+
+            if (database.UserSecretsId.HasValue())
+            {
+                var secretsStore = new SecretsStore(database.UserSecretsId);
+                if (secretsStore.ContainsKey(database.ConnectionName))
+                    return secretsStore[database.ConnectionName];
+            }
+
+            throw new InvalidOperationException("Could not find connection string.");
+        }
+
+        static JsonSerializerSettings Settings { get; }
+
+        static ModelCacheBuilder()
+        {
+            Settings = new JsonSerializerSettings
+            {
+                Formatting = Formatting.Indented,
+                DefaultValueHandling = DefaultValueHandling.Include,
+                TypeNameHandling = TypeNameHandling.All,
+                PreserveReferencesHandling = PreserveReferencesHandling.All,
+                Converters = {
+                    KeyValueTuplesJsonConverter.Instance,
+                    AnnotationsJsonConverter.Instance,
+                },
+                ContractResolver = AnnotationsContractResolver.Instance,
+            };
+        }
+
+        public static string Serialize(DatabaseModel model)
+        {
+            return JsonConvert.SerializeObject(model, Settings);
+        }
+
+        public static DatabaseModel Deserialize(string ser)
+        {
+            return JsonConvert.DeserializeObject<DatabaseModel>(ser, Settings);
+        }
+    }
+}

--- a/src/EntityFrameworkCore.Generator.Core/ModelCacheBuilder.cs
+++ b/src/EntityFrameworkCore.Generator.Core/ModelCacheBuilder.cs
@@ -12,7 +12,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 
-namespace EntityFrameworkCore.Generator.Core
+namespace EntityFrameworkCore.Generator
 {
     public class ModelCacheBuilder : IModelCacheBuilder
     {

--- a/src/EntityFrameworkCore.Generator.Core/Options/EntityClassOptions.cs
+++ b/src/EntityFrameworkCore.Generator.Core/Options/EntityClassOptions.cs
@@ -70,5 +70,11 @@ namespace EntityFrameworkCore.Generator.Options
         /// </summary>
         [DefaultValue(false)]
         public bool PrefixWithSchemaName { get; set; }
+
+        /// <summary>
+        /// If true, by default generated properties will be virtual.
+        /// </summary>
+        [DefaultValue(false)]
+        public bool VirtualProperties { get; set; }
     }
 }

--- a/src/EntityFrameworkCore.Generator.Core/Options/GeneratorOptions.cs
+++ b/src/EntityFrameworkCore.Generator.Core/Options/GeneratorOptions.cs
@@ -27,6 +27,9 @@ namespace EntityFrameworkCore.Generator.Options
         [YamlIgnore]
         public VariableDictionary Variables { get; }
 
+        [YamlIgnore]
+        public Templates.CodeTemplateWriter CodeWriter { get; set; }
+
         /// <summary>
         /// Gets the options file meta data.
         /// </summary>

--- a/src/EntityFrameworkCore.Generator.Core/Options/GeneratorOptions.cs
+++ b/src/EntityFrameworkCore.Generator.Core/Options/GeneratorOptions.cs
@@ -15,6 +15,8 @@ namespace EntityFrameworkCore.Generator.Options
         {
             Variables = new VariableDictionary();
 
+            Options = new OptionsOptions(Variables, null);
+
             Project = new ProjectOptions(Variables, null);
             Database = new DatabaseOptions(Variables, null);
             Data = new DataOptions(Variables, null);
@@ -24,6 +26,14 @@ namespace EntityFrameworkCore.Generator.Options
 
         [YamlIgnore]
         public VariableDictionary Variables { get; }
+
+        /// <summary>
+        /// Gets the options file meta data.
+        /// </summary>
+        /// <value>
+        /// The optiosn file meta data.
+        /// </value>
+        public OptionsOptions Options { get; }
 
         /// <summary>
         /// Gets or sets the project options.

--- a/src/EntityFrameworkCore.Generator.Core/Options/OptionsOptions.cs
+++ b/src/EntityFrameworkCore.Generator.Core/Options/OptionsOptions.cs
@@ -1,0 +1,87 @@
+using System;
+using System.IO;
+
+namespace EntityFrameworkCore.Generator.Options
+{
+    /// <summary>
+    /// Options file meta data.
+    /// </summary>
+    public class OptionsOptions : OptionsBase
+    {
+        public OptionsOptions(VariableDictionary variables, string prefix)
+            : base(variables, AppendPrefix(prefix, "Options"))
+        {
+        }
+
+        /// <summary>
+        /// Gets the full path to the current options file.
+        /// This value is computed and read-only, and cannot be set.
+        /// </summary>
+        /// <value>
+        /// The full path to the options file.
+        /// </value>
+        public string FullPath
+        {
+            get { return GetProperty(); }
+            set { }
+        }
+
+        /// <summary>
+        /// Gets just the directory containing the current options file.
+        /// This value is computed and read-only, and cannot be set.
+        /// </summary>
+        /// <value>
+        /// The directory containing the options file.
+        /// </value>
+        public string Directory
+        {
+            get { return GetProperty(); }
+            set { }
+        }
+
+        /// <summary>
+        /// Gets just the file name of the current options file.
+        /// This value is computed and read-only, and cannot be set.
+        /// </summary>
+        /// <value>
+        /// The file name of the options file.
+        /// </value>
+        public string FileName
+        {
+            get { return GetProperty(); }
+            set { }
+        }
+
+        /// <summary>
+        /// Gets just the file name without any extension of the current options file.
+        /// This value is computed and read-only, and cannot be set.
+        /// </summary>
+        /// <value>
+        /// The file name without any extension of the options file.
+        /// </value>
+        public string FileNameWithoutExtension
+        {
+            get { return GetProperty(); }
+            set { }
+        }
+
+        /// <summary>
+        /// Sets the full path to the current options file.
+        /// This will also resolve the Directory and File Name.
+        /// </summary>
+        public void SetFullPath(string path)
+        {
+            SetProperty(path, nameof(FullPath));
+            SetProperty(Path.GetDirectoryName(path), nameof(Directory));
+            SetProperty(Path.GetFileName(path), nameof(FileName));
+
+            // Special handling for *.efg.* sub-extension
+            var filename = Path.GetFileNameWithoutExtension(path);
+            if (filename.EndsWith(".efg", StringComparison.OrdinalIgnoreCase))
+            {
+                filename = Path.GetFileNameWithoutExtension(filename);
+            }
+            SetProperty(filename, nameof(FileNameWithoutExtension));
+        }
+    }
+}

--- a/src/EntityFrameworkCore.Generator.Core/Templates/DataContextTemplate.cs
+++ b/src/EntityFrameworkCore.Generator.Core/Templates/DataContextTemplate.cs
@@ -128,6 +128,7 @@ namespace EntityFrameworkCore.Generator.Templates
             using (CodeBuilder.Indent())
             {
                 CodeBuilder.AppendLine("#region Generated Configuration");
+                CodeBuilder.AppendLine("base.OnModelCreating(modelBuilder);");
                 foreach (var entityType in _entityContext.Entities.OrderBy(e => e.MappingClass))
                 {
                     var mappingClass = entityType.MappingClass.ToSafeName();

--- a/src/EntityFrameworkCore.Generator.Core/Templates/EntityClassTemplate.cs
+++ b/src/EntityFrameworkCore.Generator.Core/Templates/EntityClassTemplate.cs
@@ -128,7 +128,13 @@ namespace EntityFrameworkCore.Generator.Templates
                     CodeBuilder.AppendLine("/// </value>");
                 }
 
-                CodeBuilder.AppendLine($"public {propertyType} {propertyName} {{ get; set; }}");
+                var virtualKeyword = "";
+                if (Options.Data.Entity.VirtualProperties)
+                {
+                    virtualKeyword = "virtual ";
+                }
+
+                CodeBuilder.AppendLine($"public {virtualKeyword} {propertyType} {propertyName} {{ get; set; }}");
                 CodeBuilder.AppendLine();
             }
             CodeBuilder.AppendLine("#endregion");

--- a/src/EntityFrameworkCore.Generator/EntityFrameworkCore.Generator.csproj
+++ b/src/EntityFrameworkCore.Generator/EntityFrameworkCore.Generator.csproj
@@ -1,29 +1,23 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\build\common.props" />
-
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\build\common.props"/>
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <ToolCommandName>efg</ToolCommandName>
     <PackAsTool>true</PackAsTool>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <NoWarn>1591,EF1001</NoWarn>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <NoWarn>1591,EF1001</NoWarn>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.0.0" />
-    <PackageReference Include="Serilog.Extensions.Hosting" Version="3.1.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.0.0"/>
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="3.1.0"/>
+    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1"/>
   </ItemGroup>
-
   <ItemGroup>
-    <ProjectReference Include="..\EntityFrameworkCore.Generator.Core\EntityFrameworkCore.Generator.Core.csproj" />
+    <ProjectReference Include="..\EntityFrameworkCore.Generator.Core\EntityFrameworkCore.Generator.Core.csproj"/>
   </ItemGroup>
-
 </Project>

--- a/src/EntityFrameworkCore.Generator/GenerateCommand.cs
+++ b/src/EntityFrameworkCore.Generator/GenerateCommand.cs
@@ -3,6 +3,7 @@ using EntityFrameworkCore.Generator.Options;
 using McMaster.Extensions.CommandLineUtils;
 using Microsoft.Extensions.Logging;
 using System;
+using System.IO;
 
 namespace EntityFrameworkCore.Generator
 {
@@ -47,6 +48,9 @@ namespace EntityFrameworkCore.Generator
             {
                 Logger.LogInformation("Using default options");
                 options = new GeneratorOptions();
+
+                // Options file meta data
+                options.Options.SetFullPath(Path.Combine(workingDirectory, optionsFile));
             }
 
             // override options

--- a/src/EntityFrameworkCore.Generator/GenerateCommand.cs
+++ b/src/EntityFrameworkCore.Generator/GenerateCommand.cs
@@ -37,6 +37,9 @@ namespace EntityFrameworkCore.Generator
         [Option("--validator", Description = "Include model validation in generation")]
         public bool? Validator { get; set; }
 
+        [Option("--from-cache", Description = "Generate source from cached DB Model")]
+        public bool? FromCache { get; set; }
+
 
         protected override int OnExecute(CommandLineApplication application)
         {
@@ -77,7 +80,9 @@ namespace EntityFrameworkCore.Generator
             if (Validator.HasValue)
                 options.Model.Validator.Generate = Validator.Value;
 
-            var result = _codeGenerator.Generate(options);
+            var result = FromCache.HasValue
+                ? _codeGenerator.Generate(options, true, false)
+                : _codeGenerator.Generate(options);
 
             return result ? 0 : 1;
         }

--- a/src/EntityFrameworkCore.Generator/InitializeCommand.cs
+++ b/src/EntityFrameworkCore.Generator/InitializeCommand.cs
@@ -91,6 +91,9 @@ namespace EntityFrameworkCore.Generator
         {
             var options = new GeneratorOptions();
 
+            // Options file meta data
+            options.Options.SetFullPath(optionsFile);
+
             // default all to generate
             options.Data.Query.Generate = true;
             options.Model.Read.Generate = true;

--- a/src/EntityFrameworkCore.Generator/Program.cs
+++ b/src/EntityFrameworkCore.Generator/Program.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Reflection;
-using EntityFrameworkCore.Generator.Core;
 using McMaster.Extensions.CommandLineUtils;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;

--- a/src/EntityFrameworkCore.Generator/Program.cs
+++ b/src/EntityFrameworkCore.Generator/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Reflection;
+using EntityFrameworkCore.Generator.Core;
 using McMaster.Extensions.CommandLineUtils;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -9,6 +10,7 @@ namespace EntityFrameworkCore.Generator
 {
     [Command("efg", Description = "Entity Framework Core model generation tool")]
     [Subcommand(typeof(InitializeCommand))]
+    [Subcommand(typeof(RefreshCommand))]
     [Subcommand(typeof(GenerateCommand))]
     [VersionOptionFromMember("--version", MemberName = nameof(GetVersion))]
     public class Program : CommandBase
@@ -43,6 +45,7 @@ namespace EntityFrameworkCore.Generator
                     .AddSingleton(PhysicalConsole.Singleton)
                     .AddTransient<IGeneratorOptionsSerializer, GeneratorOptionsSerializer>()
                     .AddTransient<ICodeGenerator, CodeGenerator>()
+                    .AddTransient<IModelCacheBuilder, ModelCacheBuilder>()
                     .BuildServiceProvider();
 
                 var app = new CommandLineApplication<Program>();

--- a/src/EntityFrameworkCore.Generator/RefreshCommand.cs
+++ b/src/EntityFrameworkCore.Generator/RefreshCommand.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using EntityFrameworkCore.Generator.Core;
 using EntityFrameworkCore.Generator.Options;
 using McMaster.Extensions.CommandLineUtils;
 using Microsoft.Extensions.Logging;

--- a/src/EntityFrameworkCore.Generator/RefreshCommand.cs
+++ b/src/EntityFrameworkCore.Generator/RefreshCommand.cs
@@ -1,0 +1,42 @@
+using System;
+using System.IO;
+using EntityFrameworkCore.Generator.Core;
+using EntityFrameworkCore.Generator.Options;
+using McMaster.Extensions.CommandLineUtils;
+using Microsoft.Extensions.Logging;
+
+namespace EntityFrameworkCore.Generator
+{
+    [Command("refresh")]
+    public class RefreshCommand : OptionsCommandBase
+    {
+        private IModelCacheBuilder _mcb;
+
+        public RefreshCommand(ILoggerFactory logger, IConsole console,
+            IGeneratorOptionsSerializer serializer, IModelCacheBuilder mcb)
+            : base(logger, console, serializer)
+        {
+            _mcb = mcb;
+        }
+
+        protected override int OnExecute(CommandLineApplication application)
+        {
+            var workingDirectory = WorkingDirectory ?? Environment.CurrentDirectory;
+            var optionsFile = OptionsFile ?? GeneratorOptionsSerializer.OptionsFileName;
+
+            var options = Serializer.Load(workingDirectory, optionsFile);
+            if (options == null)
+            {
+                Logger.LogInformation("Using default options");
+                options = new GeneratorOptions();
+
+                // Options file meta data
+                options.Options.SetFullPath(Path.Combine(workingDirectory, optionsFile));
+            }
+
+            _mcb.Refresh(options);
+
+            return 0;
+        }
+    }
+}

--- a/test/EntityFrameworkCore.Generator.Core.Tests/CodeGeneratorTests.cs
+++ b/test/EntityFrameworkCore.Generator.Core.Tests/CodeGeneratorTests.cs
@@ -19,7 +19,7 @@ namespace EntityFrameworkCore.Generator.Core.Tests
             var generatorOptions = new GeneratorOptions();
             generatorOptions.Database.ConnectionString = Database.ConnectionString;
 
-            var generator = new CodeGenerator(NullLoggerFactory.Instance);
+            var generator = new CodeGenerator(NullLoggerFactory.Instance, null);
             var result = generator.Generate(generatorOptions);
 
 

--- a/test/EntityFrameworkCore.Generator.Core.Tests/DatabaseFixture.cs
+++ b/test/EntityFrameworkCore.Generator.Core.Tests/DatabaseFixture.cs
@@ -58,6 +58,7 @@ namespace FluentCommand.SqlServer.Tests
             var builder = new ConfigurationBuilder()
                 .AddJsonFile("appsettings.json")
                 .AddJsonFile($"appsettings.{environmentName}.json", true)
+                .AddJsonFile("appsettings.local.json", true)
                 .AddEnvironmentVariables();
 
             var configuration = builder.Build();

--- a/test/EntityFrameworkCore.Generator.Core.Tests/EntityFrameworkCore.Generator.Core.Tests.csproj
+++ b/test/EntityFrameworkCore.Generator.Core.Tests/EntityFrameworkCore.Generator.Core.Tests.csproj
@@ -53,6 +53,9 @@
     <None Update="appsettings.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="appsettings.local.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/test/EntityFrameworkCore.Generator.Core.Tests/Scripts/setup-local-sqlexpress.ps1
+++ b/test/EntityFrameworkCore.Generator.Core.Tests/Scripts/setup-local-sqlexpress.ps1
@@ -1,0 +1,10 @@
+$conn = [System.Data.SqlClient.SqlConnection]::new("Data Source=(local)\SQLEXPRESS;Integrated Security=True")
+$conn.Open()
+
+$cmnd = $conn.CreateCommand(
+$cmnd.CommandText = "CREATE DATABASE EFG_TrackerTest"
+$cmnd.ExecuteNonQuery()
+$cmnd.Dispose()
+
+$conn.Close()
+$conn.Dispose()


### PR DESCRIPTION
This PR is still a work-in-progress, and starting point for discussion.

I'm using the basic plumbing and infrastructure in EFG to build a C#9-based Source Generator.  It functions very similarly to the way that EFG does from the CLI, however, it is invoked as part of the compiler toolchain using the new Source Generator feature in .NET 5.0.

To get a sense of how this works in practice from the consumer's point of vew, you can take a look at the [`Tracker.Core-CS9Gen`](https://github.com/ebekker/EntityFrameworkCore.Generator/tree/cs9-generator/sample/Tracker/Tracker.Core-CS9Gen) sample project, which is a version of the original `Tracker.Core` sample project but adapted to use the EFG CS9 Generator (CS9Gen) which can be found [here](https://github.com/ebekker/EntityFrameworkCore.Generator/tree/cs9-generator/src/EntityFrameworkCore.Generator.CS9Generator).

To achieve this, several modifications/additions were made to the original code base, but nothing that breaks the original behavior or capabilities.  All previous functionality is preserved.

The biggest change is the introduction of an optional [_Model Cache_](https://github.com/ebekker/EntityFrameworkCore.Generator/blob/cs9-generator/src/EntityFrameworkCore.Generator.Core/ModelCacheBuilder.cs) -- a serialized form (JSON file) of the EFCore `DatabaseModel`.  A user would generate/update this cache anytime that the DB schema model is updated, and commit it with the source code.  Then the CS9 Generator emits all the generated artifacts based on this cached model file as part of the normal compiler pipeline.
