### PR TITLE
Oracle provider support

### DIFF
--- a/src/EntityFrameworkCore.Generator.Core/CodeGenerator.cs
+++ b/src/EntityFrameworkCore.Generator.Core/CodeGenerator.cs
@@ -412,6 +412,9 @@ namespace EntityFrameworkCore.Generator
                 case DatabaseProviders.Sqlite:
                     ConfigureSqliteServices(services);
                     break;
+                case DatabaseProviders.Oracle:
+                    ConfigureOracleServices(services);
+                    break;
                 default:
                     throw new NotSupportedException($"The specified provider '{provider}' is not supported.");
             }
@@ -450,6 +453,12 @@ namespace EntityFrameworkCore.Generator
         private void ConfigureSqliteServices(IServiceCollection services)
         {
             var designTimeServices = new Microsoft.EntityFrameworkCore.Sqlite.Design.Internal.SqliteDesignTimeServices();
+            designTimeServices.ConfigureDesignTimeServices(services);
+        }
+
+        private void ConfigureOracleServices(IServiceCollection services)
+        {
+            var designTimeServices = new Oracle.EntityFrameworkCore.Design.Internal.OracleDesignTimeServices();
             designTimeServices.ConfigureDesignTimeServices(services);
         }
     }

--- a/src/EntityFrameworkCore.Generator.Core/EntityFrameworkCore.Generator.Core.csproj
+++ b/src/EntityFrameworkCore.Generator.Core/EntityFrameworkCore.Generator.Core.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.3" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.2" />
+	<PackageReference Include="Oracle.EntityFrameworkCore" Version="5.21.1" />
     <PackageReference Include="YamlDotNet" Version="9.1.4" />
   </ItemGroup>
 

--- a/src/EntityFrameworkCore.Generator.Core/Options/DatabaseProviders.cs
+++ b/src/EntityFrameworkCore.Generator.Core/Options/DatabaseProviders.cs
@@ -25,6 +25,11 @@ namespace EntityFrameworkCore.Generator.Options
         /// <summary>
         /// The sqlite provider
         /// </summary>
-        Sqlite
+        Sqlite,
+
+        /// <summary>
+        /// The Oracle provider
+        /// </summary>
+        Oracle
     }
 }


### PR DESCRIPTION
For #66, using Oracle.EntityFrameworkCore 5.21.1.
Verified the generation against an oracle 11g database.