### PR TITLE
Fix version conflicts caused by PR#271

### DIFF
--- a/src/EntityFrameworkCore.Generator.Core/EntityFrameworkCore.Generator.Core.csproj
+++ b/src/EntityFrameworkCore.Generator.Core/EntityFrameworkCore.Generator.Core.csproj
@@ -20,10 +20,10 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.9.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.6" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="5.0.0" />
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="5.0.0" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="5.0.1" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.6" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.6" />


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump Pomelo.EntityFrameworkCore.MySql from 5.0.0 to 5.0.1. [(PR#271)](https://github.com/loresoft/EntityFrameworkCore.Generator/pull/271).
Hope this fix can help you.

Best regards,
sucrose