### PR TITLE
Entity Naming Filters

### DIFF
--- a/src/EntityFrameworkCore.Generator.Core/ModelGenerator.cs
+++ b/src/EntityFrameworkCore.Generator.Core/ModelGenerator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
@@ -563,11 +563,36 @@ namespace EntityFrameworkCore.Generator
         {
             var tableNaming = _options.Database.TableNaming;
             var entityNaming = _options.Data.Entity.EntityNaming;
+            var entityNamingFilters = _options.Data.Entity.EntityNamingFilters;
 
             if (tableNaming != TableNaming.Plural && entityNaming == EntityNaming.Plural)
                 name = name.Pluralize(false);
             else if (tableNaming != TableNaming.Singular && entityNaming == EntityNaming.Singular)
                 name = name.Singularize(false);
+
+            foreach (var filter in entityNamingFilters)
+            {
+                if (!string.IsNullOrEmpty(filter.Pattern))
+                {
+                    var regex = new Regex(filter.Pattern, RegexOptions.IgnoreCase);
+                    var match = regex.Match(name);
+                    if (match.Success)
+                    {
+                        var matchedName = match.Groups[0].Value;
+
+                        if (match.Groups["ClassName"].Success)
+                        {
+                            matchedName = match.Groups["ClassName"].Value;
+                        }
+                        else if (match.Groups[1].Success)
+                        {
+                            matchedName = match.Groups[1].Value;
+                        }
+
+                        name = (filter.Prefix ?? "") + matchedName + (filter.Suffix ?? "");
+                    }
+                }
+            }
 
             return name;
         }

--- a/src/EntityFrameworkCore.Generator.Core/ModelGenerator.cs
+++ b/src/EntityFrameworkCore.Generator.Core/ModelGenerator.cs
@@ -570,30 +570,33 @@ namespace EntityFrameworkCore.Generator
             else if (tableNaming != TableNaming.Singular && entityNaming == EntityNaming.Singular)
                 name = name.Singularize(false);
 
-            foreach (var filter in entityNamingFilters)
+            if (entityNamingFilters != null)
             {
-                if (!string.IsNullOrEmpty(filter.Pattern))
+                foreach (var filter in entityNamingFilters)
                 {
-                    var regex = new Regex(filter.Pattern, RegexOptions.IgnoreCase);
-                    var match = regex.Match(name);
-                    if (match.Success)
+                    if (!string.IsNullOrEmpty(filter.Pattern))
                     {
-                        var matchedName = match.Groups[0].Value;
-
-                        if (match.Groups["ClassName"].Success)
+                        var regex = new Regex(filter.Pattern, RegexOptions.IgnoreCase);
+                        var match = regex.Match(name);
+                        if (match.Success)
                         {
-                            matchedName = match.Groups["ClassName"].Value;
-                        }
-                        else if (match.Groups[1].Success)
-                        {
-                            matchedName = match.Groups[1].Value;
-                        }
+                            var matchedName = match.Groups[0].Value;
 
-                        name = (filter.Prefix ?? "") + matchedName + (filter.Suffix ?? "");
+                            if (match.Groups["ClassName"].Success)
+                            {
+                                matchedName = match.Groups["ClassName"].Value;
+                            }
+                            else if (match.Groups[1].Success)
+                            {
+                                matchedName = match.Groups[1].Value;
+                            }
+
+                            name = (filter.Prefix ?? "") + matchedName + (filter.Suffix ?? "");
+                        }
                     }
                 }
             }
-
+           
             return name;
         }
 

--- a/src/EntityFrameworkCore.Generator.Core/Options/EntityClassOptions.cs
+++ b/src/EntityFrameworkCore.Generator.Core/Options/EntityClassOptions.cs
@@ -1,4 +1,6 @@
-﻿using System;
+using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.ComponentModel;
 
 namespace EntityFrameworkCore.Generator.Options
@@ -55,6 +57,14 @@ namespace EntityFrameworkCore.Generator.Options
         /// </value>
         [DefaultValue(EntityNaming.Singular)]
         public EntityNaming EntityNaming { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Naming filters to apply to Entities
+        /// </summary>
+        /// <value>
+        /// A list of entity class naming filters
+        /// </value>
+        public IEnumerable<EntityNamingFilter> EntityNamingFilters { get; set; }
 
         /// <summary>
         /// Gets or sets the relationship property naming strategy.

--- a/src/EntityFrameworkCore.Generator.Core/Options/EntityNamingFilter.cs
+++ b/src/EntityFrameworkCore.Generator.Core/Options/EntityNamingFilter.cs
@@ -1,0 +1,23 @@
+﻿namespace EntityFrameworkCore.Generator.Options
+{
+    /// <summary>
+    /// Entity naming filter options
+    /// </summary>
+    public class EntityNamingFilter
+    {
+        /// <summary>
+        /// The regular expression pattern to match against the table name.
+        /// The pattern should specify a named group with the name ClassName that will be used to extract the class name
+        /// otherwise the first group will be used.
+        /// </summary>
+        public string Pattern { get; set; }
+        /// <summary>
+        /// A prefix to apply after pattern matching
+        /// </summary>
+        public string Prefix { get; set; }
+        /// <summary>
+        /// A suffix to apply after pattern matching
+        /// </summary>
+        public string Suffix { get; set; }
+    }
+}


### PR DESCRIPTION
I propose a way to filter entity names via regex configuration in yml

A pattern will be used to extract the entity name and optionally apply a prefix or suffix. For example, if the table name is "tblEmployees", the pattern `^tbl(?<ClassName>.*?)$` will extract "Employees"

If the pattern does not match no change will be applied to the entity name,

The extracted name can be prefixed or suffixed further.

To match all tables and apply a prefix, one might use the pattern `^.*?$`.

example configuration in `generation.yml` under `data > entity`

```yml
    entityNamingFilters:
      - pattern: ^tbl(?<ClassName>.*?)$
        prefix: 
        suffix: 
      - pattern: ^vw(?<ClassName>.*?)$
        prefix: 
        suffix: View
```