### PR TITLE
support foreign key delete rule options

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -43,7 +43,7 @@ database:
   # schemas to include or empty to include all
   schemas:
     - dbo
-  
+
   # list of expressions for tables to exclude, source is Schema.TableName
   exclude:
     - exact: dbo.SchemaVersions
@@ -90,6 +90,12 @@ data:
     directory: '{Project.Directory}\Data\Mapping'   # the mapping class output directory
     #include XML documentation
     document: false
+    # indicates how a delete operation is applied to dependent entities in a relationship when the
+    # principal is deleted or the relationship is severed.
+    # Defaults:
+    #   NoAction - when a foreign key has its Delete Rule set to No Action.
+    #   Cascade - when a foreign key has its Delete Rule set to Cascade.
+    relationshipDeleteBehavior: ClientSetNull|Restrict|SetNull|Cascade|ClientCascade|NoAction|ClientNoAction
 
   # query extension class file configuration
   query:
@@ -172,11 +178,11 @@ model:
 # script templates
 script:
   # collection script template with EntityContext as a variable
-  context:  
+  context:
     - templatePath: '.\templates\context.csx'          # path to script file
       fileName: 'ContextScript.cs'                     # filename to save script output
       directory: '{Project.Directory}\Domain\Context'  # directory to save script output
-      namespace: '{Project.Namespace}.Domain.Context'  
+      namespace: '{Project.Namespace}.Domain.Context'
       baseClass: ContextScriptBase
       overwrite: true                                  # overwrite existing file
   # collection of script template with current Entity as a variable
@@ -184,7 +190,7 @@ script:
     - templatePath: '.\templates\entity.csx'           # path to script file
       fileName: '{Entity.Name}Script.cs'               # filename to save script output
       directory: '{Project.Directory}\Domain\Entity'   # directory to save script output
-      namespace: '{Project.Namespace}.Domain.Entity'  
+      namespace: '{Project.Namespace}.Domain.Entity'
       baseClass: EntityScriptBase
       overwrite: true                                  # overwrite existing file
   # collection script template with current Model as a variable
@@ -192,13 +198,13 @@ script:
     - templatePath: '.\templates\model.csx'            # path to script file
       fileName: '{Model.Name}Script.cs'                # filename to save script output
       directory: '{Project.Directory}\Domain\Models'   # directory to save script output
-      namespace: '{Project.Namespace}.Domain.Models'  
+      namespace: '{Project.Namespace}.Domain.Models'
       baseClass: ModelScriptBase
       overwrite: true                                  # overwrite existing file
     - templatePath: '.\templates\sample.csx'           # path to script file
       fileName: '{Model.Name}Sample.cs'                # filename to save script output
       directory: '{Project.Directory}\Domain\Models'   # directory to save script output
-      namespace: '{Project.Namespace}.Domain.Models'  
+      namespace: '{Project.Namespace}.Domain.Models'
       baseClass: ModelSampleBase
       overwrite: true                                  # overwrite existing file
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -65,7 +65,7 @@ data:
 
     # how to generate names for the DbSet properties on the data context.  Default: Plural
     propertyNaming: Preserve|Plural|Suffix
-    #include XML documentation
+    # include XML documentation
     document: false
 
   # entity class file configuration
@@ -78,7 +78,7 @@ data:
 
     # how to generate relationship collections names for the entity.  Default: Plural
     relationshipNaming: Preserve|Plural|Suffix
-    #include XML documentation
+    # include XML documentation
     document: false
 
     # Generate class names with prefixed schema name eg. dbo.MyTable = DboMyTable
@@ -88,14 +88,16 @@ data:
   mapping:
     namespace: '{Project.Namespace}.Data.Mapping'   # the mapping class namespace
     directory: '{Project.Directory}\Data\Mapping'   # the mapping class output directory
-    #include XML documentation
+    # include XML documentation
     document: false
-    # indicates how a delete operation is applied to dependent entities in a relationship when the
-    # principal is deleted or the relationship is severed.
-    # Defaults:
-    #   NoAction - when a foreign key has its Delete Rule set to No Action.
-    #   Cascade - when a foreign key has its Delete Rule set to Cascade.
-    relationshipDeleteBehavior: ClientSetNull|Restrict|SetNull|Cascade|ClientCascade|NoAction|ClientNoAction
+    # globally indicates how a delete operation is applied to dependent entities in a relationship
+    # when the principal is deleted or the relationship is severed.
+    # Default: Cascade
+    globalRelationshipCascadeDeleteBehavior: Cascade|ClientCascade
+    # Default: SetNull
+    globalRelationshipSetNullDeleteBehavior: SetNull|ClientSetNull
+    # Default: NoAction
+    globalRelationshipNoActionDeleteBehavior: NoAction|ClientNoAction
 
   # query extension class file configuration
   query:
@@ -104,7 +106,7 @@ data:
     uniquePrefix: GetBy     # Prefix for queries built from unique indexes
     namespace: '{Project.Namespace}.Data.Queries'   # the mapping class namespace
     directory: '{Project.Directory}\Data\Queries'   # the mapping class output directory
-    #include XML documentation
+    # include XML documentation
     document: false
 
 #---------------------------------#

--- a/src/EntityFrameworkCore.Generator.Core/Metadata/Generation/Relationship.cs
+++ b/src/EntityFrameworkCore.Generator.Core/Metadata/Generation/Relationship.cs
@@ -1,4 +1,6 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
+
+using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace EntityFrameworkCore.Generator.Metadata.Generation;
 
@@ -32,7 +34,7 @@ public class Relationship : ModelBase
     public Cardinality PrimaryCardinality { get; set; }
 
 
-    public bool? CascadeDelete { get; set; }
+    public ReferentialAction? ReferentialAction { get; set; }
     public bool IsForeignKey { get; set; }
     public bool IsMapped { get; set; }
 

--- a/src/EntityFrameworkCore.Generator.Core/ModelGenerator.cs
+++ b/src/EntityFrameworkCore.Generator.Core/ModelGenerator.cs
@@ -259,7 +259,7 @@ public class ModelGenerator
             };
             foreignEntity.Relationships.Add(foreignRelationship);
         }
-        foreignRelationship.CascadeDelete = tableKeySchema.OnDelete == Microsoft.EntityFrameworkCore.Migrations.ReferentialAction.Cascade;
+        foreignRelationship.ReferentialAction = tableKeySchema.OnDelete;
         foreignRelationship.IsMapped = true;
         foreignRelationship.IsForeignKey = true;
         foreignRelationship.Cardinality = foreignMembersRequired ? Cardinality.One : Cardinality.ZeroOrOne;

--- a/src/EntityFrameworkCore.Generator.Core/ModelGenerator.cs
+++ b/src/EntityFrameworkCore.Generator.Core/ModelGenerator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
@@ -259,6 +259,7 @@ public class ModelGenerator
             };
             foreignEntity.Relationships.Add(foreignRelationship);
         }
+        foreignRelationship.CascadeDelete = tableKeySchema.OnDelete == Microsoft.EntityFrameworkCore.Migrations.ReferentialAction.Cascade;
         foreignRelationship.IsMapped = true;
         foreignRelationship.IsForeignKey = true;
         foreignRelationship.Cardinality = foreignMembersRequired ? Cardinality.One : Cardinality.ZeroOrOne;

--- a/src/EntityFrameworkCore.Generator.Core/Options/MappingClassOptions.cs
+++ b/src/EntityFrameworkCore.Generator.Core/Options/MappingClassOptions.cs
@@ -10,6 +10,10 @@ namespace EntityFrameworkCore.Generator.Options;
 /// <seealso cref="ClassOptionsBase" />
 public class MappingClassOptions : ClassOptionsBase
 {
+    DeleteBehavior _globalRelationshipCascadeDeleteBehavior;
+    DeleteBehavior _globalRelationshipSetNullDeleteBehavior;
+    DeleteBehavior _globalRelationshipNoActionDeleteBehavior;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="MappingClassOptions"/> class.
     /// </summary>
@@ -18,12 +22,68 @@ public class MappingClassOptions : ClassOptionsBase
     {
         Namespace = "{Project.Namespace}.Data.Mapping";
         Directory = @"{Project.Directory}\Data\Mapping";
-        RelationshipDeleteBehavior = DeleteBehavior.Cascade;
+        GlobalRelationshipCascadeDeleteBehavior = DeleteBehavior.Cascade;
+        GlobalRelationshipSetNullDeleteBehavior = DeleteBehavior.SetNull;
+        GlobalRelationshipNoActionDeleteBehavior = DeleteBehavior.NoAction;
     }
 
     /// <summary>
-    /// Gets or sets the delete behavior for all foreign keys that have cascade deletes.
+    /// Gets or sets the delete behavior globally for all relationships who's foreign keys have a insert delete <i>Cascade</i> rule set.
     /// </summary>
     [DefaultValue(DeleteBehavior.Cascade)]
-    public DeleteBehavior RelationshipDeleteBehavior { get; set; }
+    public DeleteBehavior GlobalRelationshipCascadeDeleteBehavior
+    {
+        get => _globalRelationshipCascadeDeleteBehavior;
+        set
+        {
+            if (value == DeleteBehavior.Cascade || value == DeleteBehavior.ClientCascade)
+            {
+                _globalRelationshipCascadeDeleteBehavior = value;
+            }
+            else
+            {
+                throw new InvalidEnumArgumentException($"{nameof(GlobalRelationshipCascadeDeleteBehavior)} can only be set to {nameof(DeleteBehavior.Cascade)} or {nameof(DeleteBehavior.ClientCascade)}. Received {value}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the delete behavior globally for all relationships who's foreign keys have a insert delete <i>Set Null</i> rule set.
+    /// </summary>
+    [DefaultValue(DeleteBehavior.SetNull)]
+    public DeleteBehavior GlobalRelationshipSetNullDeleteBehavior
+    {
+        get => _globalRelationshipSetNullDeleteBehavior;
+        set
+        {
+            if (value == DeleteBehavior.SetNull || value == DeleteBehavior.ClientSetNull)
+            {
+                _globalRelationshipSetNullDeleteBehavior = value;
+            }
+            else
+            {
+                throw new InvalidEnumArgumentException($"{nameof(GlobalRelationshipSetNullDeleteBehavior)} can only be set to {nameof(DeleteBehavior.SetNull)} or {nameof(DeleteBehavior.ClientSetNull)}. Received {value}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the delete behavior globally for all relationships who's foreign keys have a insert delete <i>No Action</i> rule set.
+    /// </summary>
+    [DefaultValue(DeleteBehavior.NoAction)]
+    public DeleteBehavior GlobalRelationshipNoActionDeleteBehavior
+    {
+        get => _globalRelationshipNoActionDeleteBehavior;
+        set
+        {
+            if (value != DeleteBehavior.NoAction || value != DeleteBehavior.ClientNoAction)
+            {
+                _globalRelationshipNoActionDeleteBehavior = value;
+            }
+            else
+            {
+                throw new InvalidEnumArgumentException($"{nameof(GlobalRelationshipNoActionDeleteBehavior)} can only be set to {nameof(DeleteBehavior.NoAction)} or {nameof(DeleteBehavior.ClientNoAction)}. Received {value}");
+            }
+        }
+    }
 }

--- a/src/EntityFrameworkCore.Generator.Core/Options/MappingClassOptions.cs
+++ b/src/EntityFrameworkCore.Generator.Core/Options/MappingClassOptions.cs
@@ -1,4 +1,8 @@
-﻿namespace EntityFrameworkCore.Generator.Options;
+using System.ComponentModel;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace EntityFrameworkCore.Generator.Options;
 
 /// <summary>
 /// EntityFramework mapping class generation options
@@ -14,5 +18,12 @@ public class MappingClassOptions : ClassOptionsBase
     {
         Namespace = "{Project.Namespace}.Data.Mapping";
         Directory = @"{Project.Directory}\Data\Mapping";
+        RelationshipDeleteBehavior = DeleteBehavior.Cascade;
     }
+
+    /// <summary>
+    /// Gets or sets the delete behavior for all foreign keys that have cascade deletes.
+    /// </summary>
+    [DefaultValue(DeleteBehavior.Cascade)]
+    public DeleteBehavior RelationshipDeleteBehavior { get; set; }
 }

--- a/src/EntityFrameworkCore.Generator.Core/Options/OptionsBase.cs
+++ b/src/EntityFrameworkCore.Generator.Core/Options/OptionsBase.cs
@@ -1,5 +1,8 @@
-﻿using System.Runtime.CompilerServices;
+using System.Runtime.CompilerServices;
+
 using EntityFrameworkCore.Generator.Extensions;
+
+using Microsoft.Extensions.Logging;
 
 namespace EntityFrameworkCore.Generator.Options;
 
@@ -20,6 +23,7 @@ public class OptionsBase
 
     protected string Prefix { get; }
 
+    public virtual bool Validate(ILogger logger) => true;
 
     protected string GetProperty([CallerMemberName] string propertyName = null)
     {

--- a/src/EntityFrameworkCore.Generator.Core/Templates/MappingClassTemplate.cs
+++ b/src/EntityFrameworkCore.Generator.Core/Templates/MappingClassTemplate.cs
@@ -1,8 +1,10 @@
 using System.Globalization;
 using System.Linq;
+
 using EntityFrameworkCore.Generator.Extensions;
 using EntityFrameworkCore.Generator.Metadata.Generation;
 using EntityFrameworkCore.Generator.Options;
+
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 
@@ -104,7 +106,7 @@ public class MappingClassTemplate : CodeTemplateBase
 
             CodeBuilder.AppendLine($"public const string Name = \"{_entity.TableName}\";");
         }
-            
+
         CodeBuilder.AppendLine("}");
 
         CodeBuilder.AppendLine();
@@ -228,6 +230,14 @@ public class MappingClassTemplate : CodeTemplateBase
             CodeBuilder.Append(relationship.RelationshipName);
             CodeBuilder.Append("\")");
         }
+
+        var cascadeOption = $"{nameof(DeleteBehavior)}.{nameof(DeleteBehavior.NoAction)}";
+        if (relationship.CascadeDelete == true)
+        {
+            cascadeOption = $"{nameof(DeleteBehavior)}.{Options.Data.Mapping.RelationshipDeleteBehavior}";
+        }
+        CodeBuilder.AppendLine();
+        CodeBuilder.Append($".OnDelete({cascadeOption})");
 
         CodeBuilder.DecrementIndent();
 

--- a/src/EntityFrameworkCore.Generator/EntityFrameworkCore.Generator.csproj
+++ b/src/EntityFrameworkCore.Generator/EntityFrameworkCore.Generator.csproj
@@ -15,7 +15,10 @@
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.2" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="5.0.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
-    <PackageReference Include="ThisAssembly" Version="1.1.3" />
+    <PackageReference Include="ThisAssembly" Version="1.2.12">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/EntityFrameworkCore.Generator/GenerateCommand.cs
+++ b/src/EntityFrameworkCore.Generator/GenerateCommand.cs
@@ -1,8 +1,11 @@
-﻿using EntityFrameworkCore.Generator.Extensions;
-using EntityFrameworkCore.Generator.Options;
-using McMaster.Extensions.CommandLineUtils;
-using Microsoft.Extensions.Logging;
 using System;
+
+using EntityFrameworkCore.Generator.Extensions;
+using EntityFrameworkCore.Generator.Options;
+
+using McMaster.Extensions.CommandLineUtils;
+
+using Microsoft.Extensions.Logging;
 
 namespace EntityFrameworkCore.Generator;
 
@@ -72,6 +75,21 @@ public class GenerateCommand : OptionsCommandBase
 
         if (Validator.HasValue)
             options.Model.Validator.Generate = Validator.Value;
+
+        options.Model.Read.Validate(Logger);
+        options.Model.Create.Validate(Logger);
+        options.Model.Update.Validate(Logger);
+        options.Model.Mapper.Validate(Logger);
+        options.Model.Shared.Validate(Logger);
+        options.Model.Update.Validate(Logger);
+        options.Model.Validator.Validate(Logger);
+        options.Data.Mapping.Validate(Logger);
+        options.Data.Query.Validate(Logger);
+        options.Data.Entity.Validate(Logger);
+        options.Data.Context.Validate(Logger);
+        options.Database.Validate(Logger);
+        options.Project.Validate(Logger);
+        options.Script.Validate(Logger);
 
         var result = _codeGenerator.Generate(options);
 


### PR DESCRIPTION
This adds the ability to define global behaviors to support foreign key delete rules such as `Cascade`, `Set Null`, `No Action`, and `Set Default`.

**EFG Configuration**
```
mapping:
  namespace: "{Project.Namespace}.Domain.EntityConfiguration"
  directory: '{Project.Directory}\My.Domain\EntityConfiguration'
  document: false
  globalRelationshipCascadeDeleteBehavior: Cascade
  globalRelationshipSetNullDeleteBehavior: ClientSetNull
  globalRelationshipNoActionDeleteBehavior: NoAction
```

**Output**
```
builder.HasOne(t => t.Key)
    .WithMany(t => t.KeyTags)
    .HasForeignKey(d => d.KeyId)
    .HasConstraintName("FK_KeyTag__Key_KeyId")
    .OnDelete(DeleteBehavior.Cascade);
```