### PR TITLE
date/time value generator + .net conversion

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -43,7 +43,7 @@ database:
   # schemas to include or empty to include all
   schemas:
     - dbo
-  
+
   # list of expressions for tables to exclude, source is Schema.TableName
   exclude:
     - exact: dbo.SchemaVersions
@@ -90,6 +90,8 @@ data:
     directory: '{Project.Directory}\Data\Mapping'   # the mapping class output directory
     #include XML documentation
     document: false
+    dateTimeKind: Local|Utc # configures the conversion of date/time columns as UTC in .Net. Default: Local
+    dateTimeDefaultValueGenerator: UtcValueGenerator # defines the default date/time value generator. Default: string.Empty
 
   # query extension class file configuration
   query:
@@ -172,11 +174,11 @@ model:
 # script templates
 script:
   # collection script template with EntityContext as a variable
-  context:  
+  context:
     - templatePath: '.\templates\context.csx'          # path to script file
       fileName: 'ContextScript.cs'                     # filename to save script output
       directory: '{Project.Directory}\Domain\Context'  # directory to save script output
-      namespace: '{Project.Namespace}.Domain.Context'  
+      namespace: '{Project.Namespace}.Domain.Context'
       baseClass: ContextScriptBase
       overwrite: true                                  # overwrite existing file
   # collection of script template with current Entity as a variable
@@ -184,7 +186,7 @@ script:
     - templatePath: '.\templates\entity.csx'           # path to script file
       fileName: '{Entity.Name}Script.cs'               # filename to save script output
       directory: '{Project.Directory}\Domain\Entity'   # directory to save script output
-      namespace: '{Project.Namespace}.Domain.Entity'  
+      namespace: '{Project.Namespace}.Domain.Entity'
       baseClass: EntityScriptBase
       overwrite: true                                  # overwrite existing file
   # collection script template with current Model as a variable
@@ -192,13 +194,13 @@ script:
     - templatePath: '.\templates\model.csx'            # path to script file
       fileName: '{Model.Name}Script.cs'                # filename to save script output
       directory: '{Project.Directory}\Domain\Models'   # directory to save script output
-      namespace: '{Project.Namespace}.Domain.Models'  
+      namespace: '{Project.Namespace}.Domain.Models'
       baseClass: ModelScriptBase
       overwrite: true                                  # overwrite existing file
     - templatePath: '.\templates\sample.csx'           # path to script file
       fileName: '{Model.Name}Sample.cs'                # filename to save script output
       directory: '{Project.Directory}\Domain\Models'   # directory to save script output
-      namespace: '{Project.Namespace}.Domain.Models'  
+      namespace: '{Project.Namespace}.Domain.Models'
       baseClass: ModelSampleBase
       overwrite: true                                  # overwrite existing file
 ```

--- a/src/EntityFrameworkCore.Generator.Core/Options/MappingClassOptions.cs
+++ b/src/EntityFrameworkCore.Generator.Core/Options/MappingClassOptions.cs
@@ -23,11 +23,11 @@ public class MappingClassOptions : ClassOptionsBase
     /// Specifies the <see cref="System.DateTimeKind"/> to use for date/time columns.
     /// </summary>
     [DefaultValue(DateTimeKind.Local)]
-    public DateTimeKind DateTimeKind { get; set; }
+    public DateTimeKind DateTimeKind { get; set; } = DateTimeKind.Local;
 
     /// <summary>
     /// The name of the class that will generate default values for date/time columns that have default value defined in the database.
     /// </summary>
     [DefaultValue(DateTimeKind.Local)]
-    public string DateTimeDefaultValueGenerator { get; set; }
+    public string DateTimeDefaultValueGenerator { get; set; } = string.Empty;
 }

--- a/src/EntityFrameworkCore.Generator.Core/Options/MappingClassOptions.cs
+++ b/src/EntityFrameworkCore.Generator.Core/Options/MappingClassOptions.cs
@@ -1,4 +1,7 @@
-﻿namespace EntityFrameworkCore.Generator.Options;
+﻿using System;
+using System.ComponentModel;
+
+namespace EntityFrameworkCore.Generator.Options;
 
 /// <summary>
 /// EntityFramework mapping class generation options
@@ -15,4 +18,16 @@ public class MappingClassOptions : ClassOptionsBase
         Namespace = "{Project.Namespace}.Data.Mapping";
         Directory = @"{Project.Directory}\Data\Mapping";
     }
+
+    /// <summary>
+    /// Specifies the <see cref="System.DateTimeKind"/> to use for date/time columns.
+    /// </summary>
+    [DefaultValue(DateTimeKind.Local)]
+    public DateTimeKind DateTimeKind { get; set; }
+
+    /// <summary>
+    /// The name of the class that will generate default values for date/time columns that have default value defined in the database.
+    /// </summary>
+    [DefaultValue(DateTimeKind.Local)]
+    public string DateTimeDefaultValueGenerator { get; set; }
 }

--- a/src/EntityFrameworkCore.Generator.Core/Templates/MappingClassTemplate.cs
+++ b/src/EntityFrameworkCore.Generator.Core/Templates/MappingClassTemplate.cs
@@ -292,7 +292,7 @@ public class MappingClassTemplate : CodeTemplateBase
 
         if (property.SystemType == typeof(DateTime))
         {
-            if (Options.Data.Mapping.DateTimeKind == DateTimeKind.Utc)
+            if (Options.Data.Mapping.DateTimeKind == DateTimeKind.Utc || property.Default?.IndexOf("utc", StringComparison.OrdinalIgnoreCase) > -1)
             {
                 CodeBuilder.AppendLine();
                 if (property.IsNullable == false)

--- a/src/EntityFrameworkCore.Generator/EntityFrameworkCore.Generator.csproj
+++ b/src/EntityFrameworkCore.Generator/EntityFrameworkCore.Generator.csproj
@@ -15,7 +15,10 @@
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.2" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="5.0.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
-    <PackageReference Include="ThisAssembly" Version="1.1.3" />
+    <PackageReference Include="ThisAssembly" Version="1.2.12">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
.Net & EF don't handle UTC date/time columns correctly out of the box. By default all date/time objects are created in .Net using `DateTimeKind.Local`.

This request:
- allows the definition of a global date/time value generator.
- allows the definition of a global date/time kind.

**EFG Configuration**
```
mapping:
  namespace: "{Project.Namespace}.Domain.EntityConfiguration"
  directory: '{Project.Directory}\My.Domain\EntityConfiguration'
  document: false
  dateTimeKind: Utc # configures the conversion of date/time columns as UTC in .Net
  dateTimeDefaultValueGenerator: UtcValueGenerator # defines the default date/time value generator
```

**Produces**
```
builder.Property(t => t.CreatedOn)
    .IsRequired()
    .HasColumnName("CreatedOn")
    .HasColumnType("datetime2(1)")
    .HasDefaultValueSql("(sysutcdatetime())")
    .HasConversion(t => t, t => DateTime.SpecifyKind(t, DateTimeKind.Utc))
    .HasValueGenerator<UtcValueGenerator>();
```

**Sample UtcValueGenerator**
```
internal class UtcValueGenerator : ValueGenerator<DateTime>
{
    public override bool GeneratesTemporaryValues => false;

    public override DateTime Next([NotNullAttribute] EntityEntry entry)
    {
        return DateTime.UtcNow;
    }
}
```