### PR TITLE
Use full name for generic types

### DIFF
--- a/src/EntityFrameworkCore.Generator.Core/Extensions/GenerationExtensions.cs
+++ b/src/EntityFrameworkCore.Generator.Core/Extensions/GenerationExtensions.cs
@@ -190,10 +190,22 @@ public static class GenerationExtensions
         var genericPartIndex = type.Name.IndexOf('`');
         if (genericPartIndex <= 0)
         {
-            builder.Append(type.Name);
+            if (type.Namespace.HasValue() && _defaultNamespaces.Contains(type.Namespace))
+            {
+                builder.Append(type.Name);
+            }
+            else
+            {
+                builder.Append(type.FullName ?? type.Name);
+            }
             return;
         }
 
+        if (type.Namespace.HasValue() && !_defaultNamespaces.Contains(type.Namespace))
+        {
+            builder.Append(type.Namespace);
+            builder.Append(".");
+        }
         builder.Append(type.Name, 0, genericPartIndex);
         builder.Append('<');
 

--- a/test/EntityFrameworkCore.Generator.Core.Tests/CodeGeneratorTests.cs
+++ b/test/EntityFrameworkCore.Generator.Core.Tests/CodeGeneratorTests.cs
@@ -80,6 +80,8 @@ public class CodeGeneratorTests : DatabaseTestBase
     [InlineData(typeof(List<List<string>>), "List<List<string>>")]
     [InlineData(typeof(int[]), "int[]")]
     [InlineData(typeof(string[][]), "string[][]")]
+    [InlineData(typeof(System.Net.IPAddress[]), "System.Net.IPAddress[]")]
+    [InlineData(typeof(System.ComponentModel.BindingList<int>), "System.ComponentModel.BindingList<int>")]
     public void ConvertToTypeString(Type type, string expected)
        => Assert.Equal(expected, type.ToType());
 }


### PR DESCRIPTION
Use the full name for generic types not in any of the `_defaultNamespaces` namespaces.

Instead of
        `public NpgsqlRange<int> ActiveWeeks { get; set; }`
Generates
        `public NpgsqlTypes.NpgsqlRange<int> ActiveWeeks { get; set; }`

BTW, thanks for the recent v7 release, huge improvements!