### PR TITLE
allows enable/disable relationship generation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -95,6 +95,10 @@ data:
     mappingAttributes: true
     # Generate class names with prefixed schema name eg. dbo.MyTable = DboMyTable
     prefixWithSchemaName: false
+    # process relationship navigation properties. Default: true
+    processRelationships: true
+    # process key/index helper methods. Default: true
+    processMethods: true
     # file header
     header: // Entity header
 

--- a/docs/ef/entity.md
+++ b/docs/ef/entity.md
@@ -58,6 +58,8 @@ data:
     entityNaming: Singular
     relationshipNaming: Plural
     prefixWithSchemaName: false
+    processRelationships: true
+    processMethods: true
     renaming:
       entities:
         - ^(sp|tbl|udf|vw)_
@@ -106,6 +108,14 @@ Include XML documentation for the generated class. Default: `false`
 ### mappingAttributes
 
 Include mapping attributes on the entity classes. Default: `false`
+
+### processRelationships
+
+Control if relationship navigation properties are generated. Default: `true`
+
+### processMethods
+
+Control if key and index helper methods are generated. Default: `true`
 
 ### renaming
 

--- a/src/EntityFrameworkCore.Generator.Core/ModelGenerator.cs
+++ b/src/EntityFrameworkCore.Generator.Core/ModelGenerator.cs
@@ -94,6 +94,10 @@ public partial class ModelGenerator
         var entity = entityContext.Entities.ByTable(tableSchema.Name, tableSchema.Schema)
             ?? CreateEntity(entityContext, tableSchema);
 
+        // combine per-call flags with global configuration controls
+        processRelationships = processRelationships && _options.Data.Entity.ProcessRelationships;
+        processMethods = processMethods && _options.Data.Entity.ProcessMethods;
+
         if (!entity.Properties.IsProcessed)
             CreateProperties(entity, tableSchema);
 

--- a/src/EntityFrameworkCore.Generator.Core/OptionMapper.cs
+++ b/src/EntityFrameworkCore.Generator.Core/OptionMapper.cs
@@ -148,6 +148,8 @@ public static class OptionMapper
         option.EntityNaming = entity.EntityNaming;
         option.RelationshipNaming = entity.RelationshipNaming;
         option.PrefixWithSchemaName = entity.PrefixWithSchemaName;
+        option.ProcessRelationships = entity.ProcessRelationships;
+        option.ProcessMethods = entity.ProcessMethods;
         option.MappingAttributes = entity.MappingAttributes;
 
         MapSelection(option.Renaming, entity.Renaming);

--- a/src/EntityFrameworkCore.Generator.Core/Options/EntityClassOptions.cs
+++ b/src/EntityFrameworkCore.Generator.Core/Options/EntityClassOptions.cs
@@ -20,6 +20,8 @@ public class EntityClassOptions : ClassOptionsBase
         RelationshipNaming = RelationshipNaming.Plural;
         EntityNaming = EntityNaming.Singular;
         PrefixWithSchemaName = false;
+        ProcessRelationships = true;
+        ProcessMethods = true;
 
         Renaming = new SelectionOptions(variables, AppendPrefix(prefix, "Naming"));
     }
@@ -47,6 +49,18 @@ public class EntityClassOptions : ClassOptionsBase
     /// </summary>
     [DefaultValue(false)]
     public bool PrefixWithSchemaName { get; set; }
+
+    /// <summary>
+    /// Gets or sets if table relationships are processed for entity generation. Default true
+    /// </summary>
+    [DefaultValue(true)]
+    public bool ProcessRelationships { get; set; }
+
+    /// <summary>
+    /// Gets or sets if index and key helper methods are processed for entity generation. Default true
+    /// </summary>
+    [DefaultValue(true)]
+    public bool ProcessMethods { get; set; }
 
     /// <summary>
     /// Gets or sets the renaming expressions.

--- a/src/EntityFrameworkCore.Generator.Core/Serialization/EntityClass.cs
+++ b/src/EntityFrameworkCore.Generator.Core/Serialization/EntityClass.cs
@@ -21,6 +21,8 @@ public class EntityClass : ClassBase
         RelationshipNaming = RelationshipNaming.Plural;
         EntityNaming = EntityNaming.Singular;
         PrefixWithSchemaName = false;
+        ProcessRelationships = true;
+        ProcessMethods = true;
     }
 
     /// <summary>
@@ -46,6 +48,18 @@ public class EntityClass : ClassBase
     /// </summary>
     [DefaultValue(false)]
     public bool PrefixWithSchemaName { get; set; }
+
+    /// <summary>
+    /// Gets or sets if table relationships are processed for entity generation. Default true
+    /// </summary>
+    [DefaultValue(true)]
+    public bool ProcessRelationships { get; set; }
+
+    /// <summary>
+    /// Gets or sets if index and key helper methods are processed for entity generation. Default true
+    /// </summary>
+    [DefaultValue(true)]
+    public bool ProcessMethods { get; set; }
 
     /// <summary>
     /// Gets or sets the renaming expressions.

--- a/test/EntityFrameworkCore.Generator.Core.Tests/Options/full.yaml
+++ b/test/EntityFrameworkCore.Generator.Core.Tests/Options/full.yaml
@@ -38,6 +38,8 @@ data:
     relationshipNaming: Plural
     document: false
     prefixWithSchemaName: false
+    processRelationships: true
+    processMethods: true
     renaming:
       entities:
         - ^(sp|tbl|udf|vw)_


### PR DESCRIPTION
Hi, very useful tool, thanks for that.

I had some troubles renaming generated POCOs clases using 

 entity:
    name: '{Table.Name}Entity'

I found that issue raises when table has foreign keys, so disabling processRelationships works.

So, this PR allow me disable processRelationships by yml setting.
